### PR TITLE
feat(contracts): validate state root attestation in TraceabilityAnchor

### DIFF
--- a/contracts/solidity/src/TraceabilityAnchor.sol
+++ b/contracts/solidity/src/TraceabilityAnchor.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.24;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /**
  * @title TraceabilityAnchor
@@ -24,12 +26,28 @@ contract TraceabilityAnchor is AccessControl, Pausable {
     bytes32 public constant RECALL_AUTHORITY = keccak256("RECALL_AUTHORITY");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
+    mapping(address => bool) public oracleRegistry;
+
+    event OracleRegistered(address indexed oracle);
+    event OracleRemoved(address indexed oracle);
+
     constructor(address admin) {
         _grantRole(DEFAULT_ADMIN_ROLE, admin);
         _grantRole(ANCHOR_ORACLE, admin);
         _grantRole(SHIPMENT_RECORDER, admin);
         _grantRole(RECALL_AUTHORITY, admin);
         _grantRole(PAUSER_ROLE, admin);
+    }
+
+    function registerOracle(address oracle) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(oracle != address(0), "zero address");
+        oracleRegistry[oracle] = true;
+        emit OracleRegistered(oracle);
+    }
+
+    function removeOracle(address oracle) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        oracleRegistry[oracle] = false;
+        emit OracleRemoved(oracle);
     }
 
     function pause() external onlyRole(PAUSER_ROLE) {
@@ -94,15 +112,22 @@ contract TraceabilityAnchor is AccessControl, Pausable {
      * @param producer  Name of the producing entity.
      * @param origin    Country or region of origin.
      * @param stateRoot SHA-256 hash of the lot's full state in Fabric.
+     * @param signature ECDSA signature of keccak256(abi.encodePacked(lotId, stateRoot)) by a registered oracle.
      */
     function anchorLot(
         string calldata lotId,
         string calldata producer,
         string calldata origin,
-        bytes32 stateRoot
+        bytes32 stateRoot,
+        bytes calldata signature
     ) external onlyRole(ANCHOR_ORACLE) whenNotPaused {
         require(bytes(lotId).length > 0, "lotId required");
         require(stateRoot != bytes32(0), "stateRoot required");
+
+        bytes32 messageHash = keccak256(abi.encodePacked(lotId, stateRoot));
+        bytes32 ethSignedHash = MessageHashUtils.toEthSignedMessageHash(messageHash);
+        address signer = ECDSA.recover(ethSignedHash, signature);
+        require(oracleRegistry[signer], "signer not registered oracle");
 
         lots[lotId] = LotAnchor({
             stateRootHash: stateRoot,

--- a/contracts/solidity/test/TraceabilityAnchor.t.sol
+++ b/contracts/solidity/test/TraceabilityAnchor.t.sol
@@ -7,8 +7,24 @@ import "../src/TraceabilityAnchor.sol";
 contract TraceabilityAnchorTest is Test {
     TraceabilityAnchor anchor;
 
+    uint256 internal oracleKey = 0xA11CE;
+    address internal oracleAddr;
+
     function setUp() public {
         anchor = new TraceabilityAnchor(address(this));
+        oracleAddr = vm.addr(oracleKey);
+        anchor.registerOracle(oracleAddr);
+    }
+
+    function _sign(string memory lotId, bytes32 stateRoot) internal view returns (bytes memory) {
+        bytes32 msgHash = keccak256(abi.encodePacked(lotId, stateRoot));
+        bytes32 ethHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(oracleKey, ethHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _anchorLot(string memory lotId, string memory producer, string memory origin, bytes32 stateRoot) internal {
+        anchor.anchorLot(lotId, producer, origin, stateRoot, _sign(lotId, stateRoot));
     }
 
     // ---------------------------------------------------------------
@@ -23,7 +39,7 @@ contract TraceabilityAnchorTest is Test {
             "LOT-001", root, "Green Valley Farms", block.timestamp
         );
 
-        anchor.anchorLot("LOT-001", "Green Valley Farms", "ES", root);
+        _anchorLot("LOT-001", "Green Valley Farms", "ES", root);
 
         TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("LOT-001");
         assertEq(lot.lotId, "LOT-001");
@@ -35,22 +51,82 @@ contract TraceabilityAnchorTest is Test {
 
     function test_anchorLot_reverts_on_empty_lotId() public {
         vm.expectRevert("lotId required");
-        anchor.anchorLot("", "Producer", "US", bytes32(uint256(1)));
+        anchor.anchorLot("", "Producer", "US", bytes32(uint256(1)), _sign("", bytes32(uint256(1))));
     }
 
     function test_anchorLot_reverts_on_zero_stateRoot() public {
         vm.expectRevert("stateRoot required");
-        anchor.anchorLot("LOT-X", "Producer", "US", bytes32(0));
+        anchor.anchorLot("LOT-X", "Producer", "US", bytes32(0), _sign("LOT-X", bytes32(0)));
     }
 
     function test_anchorLot_overwrites_on_reanchor() public {
         bytes32 root1 = keccak256("v1");
         bytes32 root2 = keccak256("v2");
 
-        anchor.anchorLot("LOT-002", "P1", "US", root1);
-        anchor.anchorLot("LOT-002", "P1", "US", root2);
+        _anchorLot("LOT-002", "P1", "US", root1);
+        _anchorLot("LOT-002", "P1", "US", root2);
 
         assertEq(anchor.getLot("LOT-002").stateRootHash, root2);
+    }
+
+
+    // ---------------------------------------------------------------
+    // oracle attestation
+    // ---------------------------------------------------------------
+
+    function test_anchorLot_reverts_for_unregistered_oracle_signer() public {
+        uint256 rogueKey = 0xBAD;
+        bytes32 root = keccak256("state");
+        bytes32 msgHash = keccak256(abi.encodePacked("LOT-ROGUE", root));
+        bytes32 ethHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(rogueKey, ethHash);
+        bytes memory badSig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert("signer not registered oracle");
+        anchor.anchorLot("LOT-ROGUE", "P", "US", root, badSig);
+    }
+
+    function test_anchorLot_reverts_for_tampered_payload() public {
+        bytes32 root = keccak256("state");
+        bytes memory wrongSig = _sign("LOT-DIFFERENT", root);
+
+        vm.expectRevert("signer not registered oracle");
+        anchor.anchorLot("LOT-TAMPERED", "P", "US", root, wrongSig);
+    }
+
+    function test_registerOracle_and_removeOracle() public {
+        address newOracle = address(0x1234);
+        anchor.registerOracle(newOracle);
+        assertTrue(anchor.oracleRegistry(newOracle));
+
+        anchor.removeOracle(newOracle);
+        assertFalse(anchor.oracleRegistry(newOracle));
+    }
+
+    function test_registerOracle_reverts_on_zero_address() public {
+        vm.expectRevert("zero address");
+        anchor.registerOracle(address(0));
+    }
+
+    function test_registerOracle_reverts_for_non_admin() public {
+        address outsider = address(0xBEEF);
+        vm.prank(outsider);
+        vm.expectRevert();
+        anchor.registerOracle(address(0x9999));
+    }
+
+    function test_removeOracle_reverts_for_non_admin() public {
+        address outsider = address(0xBEEF);
+        vm.prank(outsider);
+        vm.expectRevert();
+        anchor.removeOracle(oracleAddr);
+    }
+
+    function test_anchorLot_fails_after_oracle_removed() public {
+        anchor.removeOracle(oracleAddr);
+        bytes32 root = keccak256("state");
+        vm.expectRevert("signer not registered oracle");
+        anchor.anchorLot("LOT-REMOVED", "P", "US", root, _sign("LOT-REMOVED", root));
     }
 
     // ---------------------------------------------------------------
@@ -58,7 +134,7 @@ contract TraceabilityAnchorTest is Test {
     // ---------------------------------------------------------------
 
     function test_recordShipment_stores_and_emits() public {
-        anchor.anchorLot("LOT-003", "P", "MX", keccak256("s"));
+        _anchorLot("LOT-003", "P", "MX", keccak256("s"));
 
         vm.expectEmit(true, true, true, true);
         emit TraceabilityAnchor.ShipmentRecorded(
@@ -82,13 +158,13 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_recordShipment_reverts_on_empty_shipmentId() public {
-        anchor.anchorLot("LOT-004", "P", "US", keccak256("s"));
+        _anchorLot("LOT-004", "P", "US", keccak256("s"));
         vm.expectRevert("shipmentId required");
         anchor.recordShipment("", "LOT-004", "DC", 400);
     }
 
     function test_recordShipment_negative_temperature() public {
-        anchor.anchorLot("LOT-005", "P", "NO", keccak256("s"));
+        _anchorLot("LOT-005", "P", "NO", keccak256("s"));
         anchor.recordShipment("SHIP-N", "LOT-005", "Oslo DC", -250);
 
         assertEq(anchor.getShipment("SHIP-N").temperatureCelsius, -250);
@@ -99,7 +175,7 @@ contract TraceabilityAnchorTest is Test {
     // ---------------------------------------------------------------
 
     function test_issueRecall_stores_and_emits() public {
-        anchor.anchorLot("LOT-006", "P", "ES", keccak256("s"));
+        _anchorLot("LOT-006", "P", "ES", keccak256("s"));
         anchor.recordShipment("SHIP-A", "LOT-006", "Rotterdam", 400);
         anchor.recordShipment("SHIP-B", "LOT-006", "Hamburg", 500);
 
@@ -131,14 +207,14 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_issueRecall_reverts_on_zero_hash() public {
-        anchor.anchorLot("LOT-007", "P", "US", keccak256("s"));
+        _anchorLot("LOT-007", "P", "US", keccak256("s"));
         string[] memory ids = new string[](0);
         vm.expectRevert("assessmentHash required");
         anchor.issueRecall("LOT-007", bytes32(0), ids);
     }
 
     function test_issueRecall_empty_impacted_list() public {
-        anchor.anchorLot("LOT-008", "P", "US", keccak256("s"));
+        _anchorLot("LOT-008", "P", "US", keccak256("s"));
         string[] memory ids = new string[](0);
         anchor.issueRecall("LOT-008", keccak256("h"), ids);
 
@@ -163,11 +239,11 @@ contract TraceabilityAnchorTest is Test {
         address outsider = address(0xBEEF);
         vm.prank(outsider);
         vm.expectRevert();
-        anchor.anchorLot("LOT-UNAUTH", "P", "US", keccak256("s"));
+        anchor.anchorLot("LOT-UNAUTH", "P", "US", keccak256("s"), _sign("LOT-UNAUTH", keccak256("s")));
     }
 
     function test_recordShipment_reverts_for_unauthorized_caller() public {
-        anchor.anchorLot("LOT-SHIP-AUTH", "P", "US", keccak256("s"));
+        _anchorLot("LOT-SHIP-AUTH", "P", "US", keccak256("s"));
 
         address outsider = address(0xBEEF);
         vm.prank(outsider);
@@ -176,7 +252,7 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_issueRecall_reverts_for_unauthorized_caller() public {
-        anchor.anchorLot("LOT-RECALL-AUTH", "P", "US", keccak256("s"));
+        _anchorLot("LOT-RECALL-AUTH", "P", "US", keccak256("s"));
 
         address outsider = address(0xBEEF);
         string[] memory ids = new string[](0);
@@ -195,7 +271,7 @@ contract TraceabilityAnchorTest is Test {
         anchor.grantRole(anchor.RECALL_AUTHORITY(), authority);
 
         vm.prank(oracle);
-        anchor.anchorLot("LOT-ROLE", "P", "US", keccak256("s"));
+        anchor.anchorLot("LOT-ROLE", "P", "US", keccak256("s"), _sign("LOT-ROLE", keccak256("s")));
 
         vm.prank(carrier);
         anchor.recordShipment("SHIP-ROLE", "LOT-ROLE", "DC", 400);
@@ -215,18 +291,18 @@ contract TraceabilityAnchorTest is Test {
     function test_pause_blocks_anchorLot() public {
         anchor.pause();
         vm.expectRevert();
-        anchor.anchorLot("LOT-P", "P", "US", keccak256("state"));
+        anchor.anchorLot("LOT-P", "P", "US", keccak256("state"), _sign("LOT-P", keccak256("state")));
     }
 
     function test_pause_blocks_recordShipment() public {
-        anchor.anchorLot("LOT-PS", "P", "US", keccak256("state"));
+        _anchorLot("LOT-PS", "P", "US", keccak256("state"));
         anchor.pause();
         vm.expectRevert();
         anchor.recordShipment("SHIP-P", "LOT-PS", "DC", 400);
     }
 
     function test_pause_blocks_issueRecall() public {
-        anchor.anchorLot("LOT-PR", "P", "US", keccak256("state"));
+        _anchorLot("LOT-PR", "P", "US", keccak256("state"));
         anchor.pause();
         string[] memory ids = new string[](0);
         vm.expectRevert();
@@ -236,12 +312,12 @@ contract TraceabilityAnchorTest is Test {
     function test_unpause_restores_operations() public {
         anchor.pause();
         anchor.unpause();
-        anchor.anchorLot("LOT-UNPAUSE", "P", "US", keccak256("state"));
+        _anchorLot("LOT-UNPAUSE", "P", "US", keccak256("state"));
         assertGt(anchor.getLot("LOT-UNPAUSE").anchoredAt, 0);
     }
 
     function test_view_functions_work_when_paused() public {
-        anchor.anchorLot("LOT-VIEW", "P", "US", keccak256("state"));
+        _anchorLot("LOT-VIEW", "P", "US", keccak256("state"));
         anchor.pause();
         TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("LOT-VIEW");
         assertGt(lot.anchoredAt, 0);


### PR DESCRIPTION
Adds ECDSA oracle signature verification to anchorLot. Oracle registry (registerOracle/removeOracle) restricted to admin. Reverts if signer is not a registered oracle. 7 new tests (70/70 passing). Depends on #29. Closes #16