### PR TITLE
feat(contracts): add oracle attestation to TraceabilityAnchor

### DIFF
--- a/contracts/solidity/src/TraceabilityAnchor.sol
+++ b/contracts/solidity/src/TraceabilityAnchor.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.24;
 
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+
 /**
  * @title TraceabilityAnchor
  * @notice Anchors product traceability state roots from Hyperledger Fabric to
@@ -10,12 +13,15 @@ pragma solidity ^0.8.24;
  *         Each lot's provenance can be verified against the anchored hash
  *         by any participant with read access to the Fabric world state.
  *
+ *         Oracle attestation: anchorLot requires a valid ECDSA signature from
+ *         a registered oracle, ensuring only authorized cross-chain bridges
+ *         can anchor state roots.
+ *
  * @dev    Designed for consortium Besu networks with permissioned participants.
- *         Access control is kept minimal for demonstration; production
- *         deployments should integrate role-based access via OpenZeppelin
- *         AccessControl or an equivalent.
  */
 contract TraceabilityAnchor {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
     struct LotAnchor {
         bytes32 stateRootHash;
         string lotId;
@@ -43,6 +49,12 @@ contract TraceabilityAnchor {
     mapping(string => ShipmentRecord) private shipments;
     mapping(string => RecallEvent) private recalls;
 
+    address public admin;
+    mapping(address => bool) public oracleRegistry;
+
+    event OracleRegistered(address indexed oracle);
+    event OracleRemoved(address indexed oracle);
+
     event LotAnchored(
         string indexed lotId,
         bytes32 stateRootHash,
@@ -65,21 +77,58 @@ contract TraceabilityAnchor {
         uint256 issuedAt
     );
 
+    constructor() {
+        admin = msg.sender;
+    }
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "caller is not admin");
+        _;
+    }
+
+    /**
+     * @notice Register an oracle address authorized to sign state root attestations.
+     * @param oracle  The oracle's signing address.
+     */
+    function registerOracle(address oracle) external onlyAdmin {
+        require(oracle != address(0), "zero address");
+        oracleRegistry[oracle] = true;
+        emit OracleRegistered(oracle);
+    }
+
+    /**
+     * @notice Remove an oracle from the authorized set.
+     * @param oracle  The oracle address to deauthorize.
+     */
+    function removeOracle(address oracle) external onlyAdmin {
+        oracleRegistry[oracle] = false;
+        emit OracleRemoved(oracle);
+    }
+
     /**
      * @notice Anchor a product lot's state root from the Fabric world state.
+     *         Requires a valid ECDSA signature from a registered oracle over
+     *         `keccak256(abi.encodePacked(lotId, stateRoot))`.
      * @param lotId     Unique lot identifier matching the Fabric chaincode key.
      * @param producer  Name of the producing entity.
      * @param origin    Country or region of origin.
      * @param stateRoot SHA-256 hash of the lot's full state in Fabric.
+     * @param signature ECDSA signature from a registered oracle.
      */
     function anchorLot(
         string calldata lotId,
         string calldata producer,
         string calldata origin,
-        bytes32 stateRoot
+        bytes32 stateRoot,
+        bytes calldata signature
     ) external {
         require(bytes(lotId).length > 0, "lotId required");
         require(stateRoot != bytes32(0), "stateRoot required");
+
+        bytes32 digest = keccak256(abi.encodePacked(lotId, stateRoot));
+        bytes32 ethSignedHash = digest.toEthSignedMessageHash();
+        address signer = ethSignedHash.recover(signature);
+        require(oracleRegistry[signer], "signer is not a registered oracle");
 
         lots[lotId] = LotAnchor({
             stateRootHash: stateRoot,

--- a/contracts/solidity/test/TraceabilityAnchor.t.sol
+++ b/contracts/solidity/test/TraceabilityAnchor.t.sol
@@ -3,27 +3,78 @@ pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {TraceabilityAnchor} from "../src/TraceabilityAnchor.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 contract TraceabilityAnchorTest is Test {
+    using MessageHashUtils for bytes32;
+
     TraceabilityAnchor anchor;
+
+    uint256 internal oracleKey = 0xA11CE;
+    address internal oracle;
 
     function setUp() public {
         anchor = new TraceabilityAnchor();
+        oracle = vm.addr(oracleKey);
+        anchor.registerOracle(oracle);
     }
 
-    // ---------------------------------------------------------------
-    // anchorLot
-    // ---------------------------------------------------------------
+    function _sign(
+        string memory lotId,
+        bytes32 stateRoot
+    ) internal view returns (bytes memory) {
+        bytes32 digest = keccak256(abi.encodePacked(lotId, stateRoot));
+        bytes32 ethHash = digest.toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(oracleKey, ethHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // -- Oracle registry --
+
+    function test_registerOracle_emits() public {
+        address newOracle = address(0xBEEF);
+        vm.expectEmit(true, true, true, true);
+        emit TraceabilityAnchor.OracleRegistered(newOracle);
+        anchor.registerOracle(newOracle);
+        assertTrue(anchor.oracleRegistry(newOracle));
+    }
+
+    function test_registerOracle_reverts_zero_address() public {
+        vm.expectRevert("zero address");
+        anchor.registerOracle(address(0));
+    }
+
+    function test_registerOracle_reverts_for_non_admin() public {
+        vm.prank(address(0xCAFE));
+        vm.expectRevert("caller is not admin");
+        anchor.registerOracle(address(0xBEEF));
+    }
+
+    function test_removeOracle_emits() public {
+        vm.expectEmit(true, true, true, true);
+        emit TraceabilityAnchor.OracleRemoved(oracle);
+        anchor.removeOracle(oracle);
+        assertFalse(anchor.oracleRegistry(oracle));
+    }
+
+    function test_removeOracle_reverts_for_non_admin() public {
+        vm.prank(address(0xCAFE));
+        vm.expectRevert("caller is not admin");
+        anchor.removeOracle(oracle);
+    }
+
+    // -- anchorLot --
 
     function test_anchorLot_stores_and_emits() public {
         bytes32 root = keccak256("lot-state");
+        bytes memory sig = _sign("LOT-001", root);
 
         vm.expectEmit(true, true, true, true);
         emit TraceabilityAnchor.LotAnchored(
             "LOT-001", root, "Green Valley Farms", block.timestamp
         );
 
-        anchor.anchorLot("LOT-001", "Green Valley Farms", "ES", root);
+        anchor.anchorLot("LOT-001", "Green Valley Farms", "ES", root, sig);
 
         TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("LOT-001");
         assertEq(lot.lotId, "LOT-001");
@@ -34,42 +85,69 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_anchorLot_reverts_on_empty_lotId() public {
+        bytes memory sig = _sign("", bytes32(uint256(1)));
         vm.expectRevert("lotId required");
-        anchor.anchorLot("", "Producer", "US", bytes32(uint256(1)));
+        anchor.anchorLot("", "Producer", "US", bytes32(uint256(1)), sig);
     }
 
     function test_anchorLot_reverts_on_zero_stateRoot() public {
+        bytes memory sig = _sign("LOT-X", bytes32(0));
         vm.expectRevert("stateRoot required");
-        anchor.anchorLot("LOT-X", "Producer", "US", bytes32(0));
+        anchor.anchorLot("LOT-X", "Producer", "US", bytes32(0), sig);
     }
 
     function test_anchorLot_overwrites_on_reanchor() public {
         bytes32 root1 = keccak256("v1");
         bytes32 root2 = keccak256("v2");
 
-        anchor.anchorLot("LOT-002", "P1", "US", root1);
-        anchor.anchorLot("LOT-002", "P1", "US", root2);
+        anchor.anchorLot("LOT-002", "P1", "US", root1, _sign("LOT-002", root1));
+        anchor.anchorLot("LOT-002", "P1", "US", root2, _sign("LOT-002", root2));
 
         assertEq(anchor.getLot("LOT-002").stateRootHash, root2);
     }
 
-    // ---------------------------------------------------------------
-    // recordShipment
-    // ---------------------------------------------------------------
+    function test_anchorLot_reverts_for_unregistered_oracle() public {
+        uint256 rogueKey = 0xBAD;
+        bytes32 root = keccak256("rogue");
+        bytes32 digest = keccak256(abi.encodePacked("LOT-R", root));
+        bytes32 ethHash = digest.toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(rogueKey, ethHash);
+        bytes memory rogueSig = abi.encodePacked(r, s, v);
+
+        vm.expectRevert("signer is not a registered oracle");
+        anchor.anchorLot("LOT-R", "P", "US", root, rogueSig);
+    }
+
+    function test_anchorLot_reverts_for_invalid_signature() public {
+        bytes32 root = keccak256("tampered");
+        bytes memory wrongSig = _sign("LOT-T", keccak256("original"));
+
+        vm.expectRevert("signer is not a registered oracle");
+        anchor.anchorLot("LOT-T", "P", "US", root, wrongSig);
+    }
+
+    function test_anchorLot_reverts_after_oracle_removed() public {
+        anchor.removeOracle(oracle);
+        bytes32 root = keccak256("s");
+        bytes memory sig = _sign("LOT-REM", root);
+
+        vm.expectRevert("signer is not a registered oracle");
+        anchor.anchorLot("LOT-REM", "P", "US", root, sig);
+    }
+
+    // -- recordShipment --
 
     function test_recordShipment_stores_and_emits() public {
-        anchor.anchorLot("LOT-003", "P", "MX", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-003", "P", "MX", root, _sign("LOT-003", root));
 
         vm.expectEmit(true, true, true, true);
         emit TraceabilityAnchor.ShipmentRecorded(
             "SHIP-001", "LOT-003", "Houston DC", 590, block.timestamp
         );
-
         anchor.recordShipment("SHIP-001", "LOT-003", "Houston DC", 590);
 
-        TraceabilityAnchor.ShipmentRecord memory rec =
-            anchor.getShipment("SHIP-001");
-
+        TraceabilityAnchor.ShipmentRecord memory rec = anchor.getShipment("SHIP-001");
         assertEq(rec.shipmentId, "SHIP-001");
         assertEq(rec.lotId, "LOT-003");
         assertEq(rec.destination, "Houston DC");
@@ -82,24 +160,24 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_recordShipment_reverts_on_empty_shipmentId() public {
-        anchor.anchorLot("LOT-004", "P", "US", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-004", "P", "US", root, _sign("LOT-004", root));
         vm.expectRevert("shipmentId required");
         anchor.recordShipment("", "LOT-004", "DC", 400);
     }
 
     function test_recordShipment_negative_temperature() public {
-        anchor.anchorLot("LOT-005", "P", "NO", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-005", "P", "NO", root, _sign("LOT-005", root));
         anchor.recordShipment("SHIP-N", "LOT-005", "Oslo DC", -250);
-
         assertEq(anchor.getShipment("SHIP-N").temperatureCelsius, -250);
     }
 
-    // ---------------------------------------------------------------
-    // issueRecall
-    // ---------------------------------------------------------------
+    // -- issueRecall --
 
     function test_issueRecall_stores_and_emits() public {
-        anchor.anchorLot("LOT-006", "P", "ES", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-006", "P", "ES", root, _sign("LOT-006", root));
         anchor.recordShipment("SHIP-A", "LOT-006", "Rotterdam", 400);
         anchor.recordShipment("SHIP-B", "LOT-006", "Hamburg", 500);
 
@@ -109,15 +187,10 @@ contract TraceabilityAnchorTest is Test {
         impacted[1] = "SHIP-B";
 
         vm.expectEmit(true, true, true, true);
-        emit TraceabilityAnchor.RecallIssued(
-            "LOT-006", assessHash, 2, block.timestamp
-        );
-
+        emit TraceabilityAnchor.RecallIssued("LOT-006", assessHash, 2, block.timestamp);
         anchor.issueRecall("LOT-006", assessHash, impacted);
 
-        TraceabilityAnchor.RecallEvent memory recall =
-            anchor.getRecall("LOT-006");
-
+        TraceabilityAnchor.RecallEvent memory recall = anchor.getRecall("LOT-006");
         assertEq(recall.lotId, "LOT-006");
         assertEq(recall.assessmentHash, assessHash);
         assertEq(recall.impactedShipmentIds.length, 2);
@@ -131,23 +204,22 @@ contract TraceabilityAnchorTest is Test {
     }
 
     function test_issueRecall_reverts_on_zero_hash() public {
-        anchor.anchorLot("LOT-007", "P", "US", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-007", "P", "US", root, _sign("LOT-007", root));
         string[] memory ids = new string[](0);
         vm.expectRevert("assessmentHash required");
         anchor.issueRecall("LOT-007", bytes32(0), ids);
     }
 
     function test_issueRecall_empty_impacted_list() public {
-        anchor.anchorLot("LOT-008", "P", "US", keccak256("s"));
+        bytes32 root = keccak256("s");
+        anchor.anchorLot("LOT-008", "P", "US", root, _sign("LOT-008", root));
         string[] memory ids = new string[](0);
         anchor.issueRecall("LOT-008", keccak256("h"), ids);
-
         assertEq(anchor.getRecall("LOT-008").impactedShipmentIds.length, 0);
     }
 
-    // ---------------------------------------------------------------
-    // getLot — unknown
-    // ---------------------------------------------------------------
+    // -- getLot unknown --
 
     function test_getLot_returns_empty_for_unknown() public view {
         TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("UNKNOWN");

--- a/contracts/solidity/test/invariants/TraceabilityAnchorHandler.sol
+++ b/contracts/solidity/test/invariants/TraceabilityAnchorHandler.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.24;
 
 import {TraceabilityAnchor} from "../../src/TraceabilityAnchor.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 /**
  * @title TraceabilityAnchorHandler
@@ -10,7 +12,12 @@ import {TraceabilityAnchor} from "../../src/TraceabilityAnchor.sol";
  *         anchored lots and recorded shipments.
  */
 contract TraceabilityAnchorHandler {
+    using MessageHashUtils for bytes32;
+
+    Vm private constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
     TraceabilityAnchor public immutable ANCHOR;
+    uint256 internal immutable ORACLE_KEY;
 
     string[] internal _lotIds;
     string[] internal _shipmentIds;
@@ -18,8 +25,16 @@ contract TraceabilityAnchorHandler {
     uint256 internal _lotCounter;
     uint256 internal _shipmentCounter;
 
-    constructor(TraceabilityAnchor _anchor) {
+    constructor(TraceabilityAnchor _anchor, uint256 oracleKey) {
         ANCHOR = _anchor;
+        ORACLE_KEY = oracleKey;
+    }
+
+    function _signLot(string memory lotId, bytes32 stateRoot) internal view returns (bytes memory) {
+        bytes32 digest = keccak256(abi.encodePacked(lotId, stateRoot));
+        bytes32 ethHash = digest.toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = VM.sign(ORACLE_KEY, ethHash);
+        return abi.encodePacked(r, s, v);
     }
 
     // --------------- fuzzed actions ---------------
@@ -30,8 +45,9 @@ contract TraceabilityAnchorHandler {
         }
 
         string memory lid = string(abi.encodePacked("LOT-", _uint2str(++_lotCounter)));
+        bytes memory sig = _signLot(lid, stateRootSeed);
 
-        ANCHOR.anchorLot(lid, "producer", "origin", stateRootSeed);
+        ANCHOR.anchorLot(lid, "producer", "origin", stateRootSeed, sig);
         _lotIds.push(lid);
     }
 

--- a/contracts/solidity/test/invariants/TraceabilityAnchorInvariant.t.sol
+++ b/contracts/solidity/test/invariants/TraceabilityAnchorInvariant.t.sol
@@ -16,9 +16,12 @@ contract TraceabilityAnchorInvariant is Test {
     TraceabilityAnchor anchor;
     TraceabilityAnchorHandler handler;
 
+    uint256 internal constant ORACLE_KEY = 0xA11CE;
+
     function setUp() public {
         anchor = new TraceabilityAnchor();
-        handler = new TraceabilityAnchorHandler(anchor);
+        anchor.registerOracle(vm.addr(ORACLE_KEY));
+        handler = new TraceabilityAnchorHandler(anchor, ORACLE_KEY);
 
         targetContract(address(handler));
     }


### PR DESCRIPTION
Adds ECDSA signature-based oracle attestation to anchorLot. Oracle registry with admin-only management. All 50 Solidity tests passing including 8 new oracle tests. Closes #16.