### PR TITLE
feat: add Pausable emergency stop to all Solidity contracts

### DIFF
--- a/contracts/solidity/src/AidSettlement.sol
+++ b/contracts/solidity/src/AidSettlement.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.24;
 
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
 /**
  * @title AidSettlement
  * @notice On-chain reconciliation anchoring for aid voucher redemption.
@@ -15,7 +17,31 @@ pragma solidity ^0.8.24;
  *         mirrors the off-chain AidSettlementLedger reconciliation rules so
  *         that settlement outcomes can be independently verified.
  */
-contract AidSettlement {
+contract AidSettlement is Pausable {
+    address public immutable ADMIN;
+
+    modifier onlyAdmin() {
+        _onlyAdmin();
+        _;
+    }
+
+    function _onlyAdmin() internal view {
+        require(msg.sender == ADMIN, "caller is not admin");
+    }
+
+    constructor(address admin) {
+        require(admin != address(0), "admin required");
+        ADMIN = admin;
+    }
+
+    function pause() external onlyAdmin {
+        _pause();
+    }
+
+    function unpause() external onlyAdmin {
+        _unpause();
+    }
+
     struct Grant {
         string grantId;
         string beneficiaryId;
@@ -88,7 +114,7 @@ contract AidSettlement {
         uint256 expiresAt,
         string[] calldata approvedCategories,
         uint256 amountUsd100
-    ) external {
+    ) external whenNotPaused {
         require(bytes(grantId).length > 0, "grantId required");
         require(!grants[grantId].exists, "grant already registered");
         require(expiresAt > issuedAt, "expiresAt must be after issuedAt");
@@ -130,7 +156,7 @@ contract AidSettlement {
         string calldata invoiceRef,
         uint256 amountUsd100,
         uint256 submittedAt
-    ) external {
+    ) external whenNotPaused {
         require(bytes(claimId).length > 0, "claimId required");
         require(bytes(invoiceRef).length > 0, "invoiceRef required");
         require(bytes(claims[claimId].claimId).length == 0, "claim already exists");

--- a/contracts/solidity/src/AidSettlementUpgradeable.sol
+++ b/contracts/solidity/src/AidSettlementUpgradeable.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 
 /**
  * @title AidSettlementUpgradeable
@@ -20,7 +21,7 @@ import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Own
  *
  * @custom:storage-location erc7201:enterprise-blockchain.storage.AidSettlement
  */
-contract AidSettlementUpgradeable is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+contract AidSettlementUpgradeable is Initializable, UUPSUpgradeable, OwnableUpgradeable, PausableUpgradeable {
     struct Grant {
         string grantId;
         string beneficiaryId;
@@ -101,11 +102,20 @@ contract AidSettlementUpgradeable is Initializable, UUPSUpgradeable, OwnableUpgr
     function initialize(address admin) external initializer {
         __Ownable_init(admin);
         __UUPSUpgradeable_init();
+        __Pausable_init();
         _getAidSettlementStorage().version = "1";
     }
 
     function version() external view returns (string memory) {
         return _getAidSettlementStorage().version;
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     function registerGrant(
@@ -116,7 +126,7 @@ contract AidSettlementUpgradeable is Initializable, UUPSUpgradeable, OwnableUpgr
         uint256 expiresAt,
         string[] calldata approvedCategories,
         uint256 amountUsd100
-    ) external {
+    ) external whenNotPaused {
         AidSettlementStorage storage $ = _getAidSettlementStorage();
         require(bytes(grantId).length > 0, "grantId required");
         require(!$.grants[grantId].exists, "grant already registered");
@@ -145,7 +155,7 @@ contract AidSettlementUpgradeable is Initializable, UUPSUpgradeable, OwnableUpgr
         string calldata invoiceRef,
         uint256 amountUsd100,
         uint256 submittedAt
-    ) external {
+    ) external whenNotPaused {
         AidSettlementStorage storage $ = _getAidSettlementStorage();
         require(bytes(claimId).length > 0, "claimId required");
         require(bytes(invoiceRef).length > 0, "invoiceRef required");

--- a/contracts/solidity/src/ConsortiumOrderRegistry.sol
+++ b/contracts/solidity/src/ConsortiumOrderRegistry.sol
@@ -1,7 +1,25 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-contract ConsortiumOrderRegistry {
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+contract ConsortiumOrderRegistry is Pausable {
+    address public immutable ADMIN;
+
+    modifier onlyAdmin() {
+        _onlyAdmin();
+        _;
+    }
+
+    function _onlyAdmin() internal view {
+        require(msg.sender == ADMIN, "caller is not admin");
+    }
+
+    constructor(address admin) {
+        require(admin != address(0), "admin required");
+        ADMIN = admin;
+    }
+
     struct CanonicalOrder {
         string orderId;
         string buyer;
@@ -35,12 +53,20 @@ contract ConsortiumOrderRegistry {
         uint256 publishedAt
     );
 
+    function pause() external onlyAdmin {
+        _pause();
+    }
+
+    function unpause() external onlyAdmin {
+        _unpause();
+    }
+
     function anchorOrder(
         string calldata orderId,
         string calldata buyer,
         string calldata supplier,
         string calldata auditProof
-    ) external {
+    ) external whenNotPaused {
         require(bytes(orderId).length > 0, "orderId required");
         require(bytes(auditProof).length > 0, "auditProof required");
         require(canonicalOrders[orderId].anchoredAt == 0, "order already anchored");
@@ -61,7 +87,7 @@ contract ConsortiumOrderRegistry {
         string calldata audience,
         string calldata payload,
         string calldata auditProof
-    ) external {
+    ) external whenNotPaused {
         require(bytes(canonicalOrders[orderId].orderId).length > 0, "order not anchored");
         require(bytes(audience).length > 0, "audience required");
         require(bytes(auditProof).length > 0, "auditProof required");

--- a/contracts/solidity/src/TraceabilityAnchor.sol
+++ b/contracts/solidity/src/TraceabilityAnchor.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.24;
 
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
 /**
  * @title TraceabilityAnchor
  * @notice Anchors product traceability state roots from Hyperledger Fabric to
@@ -15,7 +17,31 @@ pragma solidity ^0.8.24;
  *         deployments should integrate role-based access via OpenZeppelin
  *         AccessControl or an equivalent.
  */
-contract TraceabilityAnchor {
+contract TraceabilityAnchor is Pausable {
+    address public immutable ADMIN;
+
+    modifier onlyAdmin() {
+        _onlyAdmin();
+        _;
+    }
+
+    function _onlyAdmin() internal view {
+        require(msg.sender == ADMIN, "caller is not admin");
+    }
+
+    constructor(address admin) {
+        require(admin != address(0), "admin required");
+        ADMIN = admin;
+    }
+
+    function pause() external onlyAdmin {
+        _pause();
+    }
+
+    function unpause() external onlyAdmin {
+        _unpause();
+    }
+
     struct LotAnchor {
         bytes32 stateRootHash;
         string lotId;
@@ -77,7 +103,7 @@ contract TraceabilityAnchor {
         string calldata producer,
         string calldata origin,
         bytes32 stateRoot
-    ) external {
+    ) external whenNotPaused {
         require(bytes(lotId).length > 0, "lotId required");
         require(stateRoot != bytes32(0), "stateRoot required");
 
@@ -104,7 +130,7 @@ contract TraceabilityAnchor {
         string calldata lotId,
         string calldata destination,
         int256 tempC100
-    ) external {
+    ) external whenNotPaused {
         require(lots[lotId].anchoredAt > 0, "lot not anchored");
         require(bytes(shipmentId).length > 0, "shipmentId required");
         require(shipments[shipmentId].recordedAt == 0, "shipment already recorded");
@@ -130,7 +156,7 @@ contract TraceabilityAnchor {
         string calldata lotId,
         bytes32 assessmentHash,
         string[] calldata impactedShipmentIds
-    ) external {
+    ) external whenNotPaused {
         require(lots[lotId].anchoredAt > 0, "lot not anchored");
         require(assessmentHash != bytes32(0), "assessmentHash required");
 

--- a/contracts/solidity/test/AidSettlement.t.sol
+++ b/contracts/solidity/test/AidSettlement.t.sol
@@ -6,11 +6,12 @@ import {AidSettlement} from "../src/AidSettlement.sol";
 
 contract AidSettlementTest is Test {
     AidSettlement settlement;
+    address admin = address(this);
 
     string[] twoCategories;
 
     function setUp() public {
-        settlement = new AidSettlement();
+        settlement = new AidSettlement(admin);
         twoCategories = new string[](2);
         twoCategories[0] = "groceries";
         twoCategories[1] = "pharmacy";
@@ -211,5 +212,70 @@ contract AidSettlementTest is Test {
         AidSettlement.Claim memory c = settlement.getClaim("UNKNOWN");
         assertEq(bytes(c.claimId).length, 0);
         assertEq(uint8(c.status), uint8(AidSettlement.ClaimStatus.Pending));
+    }
+
+    // ---------------------------------------------------------------
+    // Pausable
+    // ---------------------------------------------------------------
+
+    function test_pause_reverts_when_not_admin() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        settlement.pause();
+    }
+
+    function test_unpause_reverts_when_not_admin() public {
+        settlement.pause();
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        settlement.unpause();
+    }
+
+    function test_registerGrant_reverts_when_paused() public {
+        settlement.pause();
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        settlement.registerGrant(
+            "G-P", "HH", "P", 1000, 2000, twoCategories, 100
+        );
+    }
+
+    function test_submitClaim_reverts_when_paused() public {
+        settlement.registerGrant(
+            "G-P2", "HH", "P", 1000, 2000, twoCategories, 18000
+        );
+        settlement.pause();
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        settlement.submitClaim(
+            "C-P", "G-P2", "M", "groceries", "INV-P", 100, 1500
+        );
+    }
+
+    function test_views_callable_when_paused() public {
+        settlement.registerGrant(
+            "G-V", "HH", "P", 1000, 2000, twoCategories, 18000
+        );
+        settlement.submitClaim(
+            "C-V", "G-V", "M", "groceries", "INV-V", 100, 1500
+        );
+        settlement.pause();
+
+        AidSettlement.Grant memory g = settlement.getGrant("G-V");
+        assertEq(g.grantId, "G-V");
+
+        AidSettlement.Claim memory c = settlement.getClaim("C-V");
+        assertEq(c.claimId, "C-V");
+    }
+
+    function test_unpause_restores_functionality() public {
+        settlement.pause();
+        settlement.unpause();
+
+        settlement.registerGrant(
+            "G-UN", "HH", "P", 1000, 2000, twoCategories, 18000
+        );
+
+        AidSettlement.Grant memory g = settlement.getGrant("G-UN");
+        assertTrue(g.exists);
     }
 }

--- a/contracts/solidity/test/ConsortiumOrderRegistry.t.sol
+++ b/contracts/solidity/test/ConsortiumOrderRegistry.t.sol
@@ -6,9 +6,10 @@ import {ConsortiumOrderRegistry} from "../src/ConsortiumOrderRegistry.sol";
 
 contract ConsortiumOrderRegistryTest is Test {
     ConsortiumOrderRegistry registry;
+    address admin = address(this);
 
     function setUp() public {
-        registry = new ConsortiumOrderRegistry();
+        registry = new ConsortiumOrderRegistry(admin);
     }
 
     function test_anchorOrder_stores_and_emits() public {
@@ -106,5 +107,61 @@ contract ConsortiumOrderRegistryTest is Test {
 
         assertEq(order.anchoredAt, 0);
         assertEq(bytes(order.orderId).length, 0);
+    }
+
+    // ---------------------------------------------------------------
+    // Pausable
+    // ---------------------------------------------------------------
+
+    function test_pause_reverts_when_not_admin() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        registry.pause();
+    }
+
+    function test_unpause_reverts_when_not_admin() public {
+        registry.pause();
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        registry.unpause();
+    }
+
+    function test_anchorOrder_reverts_when_paused() public {
+        registry.pause();
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        registry.anchorOrder("PO-P", "Acme", "Supplier", "proof");
+    }
+
+    function test_publishAudienceView_reverts_when_paused() public {
+        registry.anchorOrder("PO-P2", "B", "S", "p");
+        registry.pause();
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        registry.publishAudienceView("PO-P2", "bank", "{}", "proof");
+    }
+
+    function test_views_callable_when_paused() public {
+        registry.anchorOrder("PO-V", "B", "S", "p");
+        registry.publishAudienceView("PO-V", "bank", "data", "proof");
+        registry.pause();
+
+        ConsortiumOrderRegistry.CanonicalOrder memory order =
+            registry.getCanonicalOrder("PO-V");
+        assertEq(order.orderId, "PO-V");
+
+        ConsortiumOrderRegistry.AudienceView memory av =
+            registry.getAudienceView("PO-V", "bank");
+        assertEq(av.payload, "data");
+    }
+
+    function test_unpause_restores_functionality() public {
+        registry.pause();
+        registry.unpause();
+
+        registry.anchorOrder("PO-UN", "B", "S", "p");
+
+        ConsortiumOrderRegistry.CanonicalOrder memory order =
+            registry.getCanonicalOrder("PO-UN");
+        assertGt(order.anchoredAt, 0);
     }
 }

--- a/contracts/solidity/test/TraceabilityAnchor.t.sol
+++ b/contracts/solidity/test/TraceabilityAnchor.t.sol
@@ -6,9 +6,10 @@ import {TraceabilityAnchor} from "../src/TraceabilityAnchor.sol";
 
 contract TraceabilityAnchorTest is Test {
     TraceabilityAnchor anchor;
+    address admin = address(this);
 
     function setUp() public {
-        anchor = new TraceabilityAnchor();
+        anchor = new TraceabilityAnchor(admin);
     }
 
     // ---------------------------------------------------------------
@@ -153,5 +154,73 @@ contract TraceabilityAnchorTest is Test {
         TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("UNKNOWN");
         assertEq(lot.anchoredAt, 0);
         assertEq(lot.stateRootHash, bytes32(0));
+    }
+
+    // ---------------------------------------------------------------
+    // Pausable
+    // ---------------------------------------------------------------
+
+    function test_pause_reverts_when_not_admin() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        anchor.pause();
+    }
+
+    function test_unpause_reverts_when_not_admin() public {
+        anchor.pause();
+        vm.prank(address(0xBEEF));
+        vm.expectRevert("caller is not admin");
+        anchor.unpause();
+    }
+
+    function test_anchorLot_reverts_when_paused() public {
+        anchor.pause();
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        anchor.anchorLot("LOT-P", "P", "US", keccak256("s"));
+    }
+
+    function test_recordShipment_reverts_when_paused() public {
+        anchor.anchorLot("LOT-P2", "P", "US", keccak256("s"));
+        anchor.pause();
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        anchor.recordShipment("SHIP-P", "LOT-P2", "DC", 400);
+    }
+
+    function test_issueRecall_reverts_when_paused() public {
+        anchor.anchorLot("LOT-P3", "P", "US", keccak256("s"));
+        anchor.pause();
+
+        string[] memory ids = new string[](0);
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        anchor.issueRecall("LOT-P3", keccak256("h"), ids);
+    }
+
+    function test_views_callable_when_paused() public {
+        anchor.anchorLot("LOT-V", "P", "US", keccak256("s"));
+        anchor.recordShipment("SHIP-V", "LOT-V", "DC", 400);
+
+        string[] memory ids = new string[](1);
+        ids[0] = "SHIP-V";
+        anchor.issueRecall("LOT-V", keccak256("recall"), ids);
+
+        anchor.pause();
+
+        TraceabilityAnchor.LotAnchor memory lot = anchor.getLot("LOT-V");
+        assertEq(lot.lotId, "LOT-V");
+
+        TraceabilityAnchor.ShipmentRecord memory ship = anchor.getShipment("SHIP-V");
+        assertEq(ship.shipmentId, "SHIP-V");
+
+        TraceabilityAnchor.RecallEvent memory recall = anchor.getRecall("LOT-V");
+        assertEq(recall.lotId, "LOT-V");
+    }
+
+    function test_unpause_restores_functionality() public {
+        anchor.pause();
+        anchor.unpause();
+
+        anchor.anchorLot("LOT-UN", "P", "US", keccak256("s"));
+        assertGt(anchor.getLot("LOT-UN").anchoredAt, 0);
     }
 }

--- a/contracts/solidity/test/invariants/AidSettlementInvariant.t.sol
+++ b/contracts/solidity/test/invariants/AidSettlementInvariant.t.sol
@@ -17,7 +17,7 @@ contract AidSettlementInvariant is Test {
     AidSettlementHandler handler;
 
     function setUp() public {
-        settlement = new AidSettlement();
+        settlement = new AidSettlement(address(this));
         handler = new AidSettlementHandler(settlement);
 
         // Only fuzz through the handler — never call the settlement directly

--- a/contracts/solidity/test/invariants/TraceabilityAnchorInvariant.t.sol
+++ b/contracts/solidity/test/invariants/TraceabilityAnchorInvariant.t.sol
@@ -17,7 +17,7 @@ contract TraceabilityAnchorInvariant is Test {
     TraceabilityAnchorHandler handler;
 
     function setUp() public {
-        anchor = new TraceabilityAnchor();
+        anchor = new TraceabilityAnchor(address(this));
         handler = new TraceabilityAnchorHandler(anchor);
 
         targetContract(address(handler));


### PR DESCRIPTION
Adds OpenZeppelin Pausable emergency stop to AidSettlement, ConsortiumOrderRegistry, TraceabilityAnchor, and AidSettlementUpgradeable. State-changing functions gated with whenNotPaused. pause/unpause restricted to admin. View functions remain callable when paused. 64 tests pass including invariant suites. Closes #15