### PR TITLE
feat(mpc): add configurable 256-bit field arithmetic

### DIFF
--- a/modules/mpc/src/field.ts
+++ b/modules/mpc/src/field.ts
@@ -1,0 +1,224 @@
+/**
+ * Finite field arithmetic for Shamir Secret Sharing.
+ *
+ * Two field sizes are supported:
+ * - **Demo mode** (default): 2^31 - 1 (Mersenne prime, fast, fits in JS Number)
+ * - **Production mode**: 2^256 - 2^32 - 977 (secp256k1 order, cryptographically secure)
+ *
+ * WARNING: Demo mode is NOT secure for production use.
+ * The small field allows brute-force enumeration in seconds.
+ *
+ * @see skills/mpc-secret-sharing.md for security guidance
+ * @see docs/adr/ADR-0004-field-arithmetic-for-mpc.md for design rationale
+ */
+
+import { randomBytes } from "node:crypto";
+
+/**
+ * Demo field: Mersenne prime 2^31 - 1.
+ * Fast arithmetic, fits in JS safe integer range.
+ * NOT SECURE for production - enumerable in ~seconds on modern hardware.
+ */
+export const DEMO_PRIME = 2_147_483_647n;
+
+/**
+ * Production field: secp256k1 curve order.
+ * 256-bit prime providing 128+ bits of security against enumeration.
+ * Used by Bitcoin, Ethereum, and most production secret sharing implementations.
+ */
+export const PRODUCTION_PRIME =
+  0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n;
+
+/**
+ * Alternative production field: 2^255 - 19 (Curve25519 prime).
+ * Slightly faster modular reduction due to special form.
+ */
+export const CURVE25519_PRIME =
+  0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffedn;
+
+export type FieldMode = "demo" | "production";
+
+export interface FieldConfig {
+  mode: FieldMode;
+  prime: bigint;
+}
+
+/**
+ * Get field configuration from environment or explicit parameter.
+ *
+ * Environment variable: MPC_FIELD_MODE ("demo" | "production")
+ * Default: "demo" for backward compatibility
+ */
+export function getFieldConfig(mode?: FieldMode): FieldConfig {
+  const envMode = process.env.MPC_FIELD_MODE;
+  const rawMode = mode ?? envMode ?? "demo";
+
+  // Validate the mode is one of the allowed values
+  if (rawMode !== "demo" && rawMode !== "production") {
+    throw new Error(
+      `Invalid MPC_FIELD_MODE: "${rawMode}". Use "demo" or "production".`,
+    );
+  }
+
+  const effectiveMode: FieldMode = rawMode;
+
+  return {
+    mode: effectiveMode,
+    prime: effectiveMode === "production" ? PRODUCTION_PRIME : DEMO_PRIME,
+  };
+}
+
+/**
+ * Field arithmetic operations for a given prime.
+ */
+export class FieldArithmetic {
+  readonly prime: bigint;
+  readonly mode: FieldMode;
+
+  constructor(config: FieldConfig = getFieldConfig()) {
+    this.prime = config.prime;
+    this.mode = config.mode;
+  }
+
+  /**
+   * Modular reduction: ensures result is in [0, prime).
+   */
+  mod(a: bigint): bigint {
+    return ((a % this.prime) + this.prime) % this.prime;
+  }
+
+  /**
+   * Modular addition: (a + b) mod prime.
+   */
+  add(a: bigint, b: bigint): bigint {
+    return this.mod(a + b);
+  }
+
+  /**
+   * Modular subtraction: (a - b) mod prime.
+   */
+  sub(a: bigint, b: bigint): bigint {
+    return this.mod(a - b);
+  }
+
+  /**
+   * Modular multiplication: (a * b) mod prime.
+   */
+  mul(a: bigint, b: bigint): bigint {
+    return this.mod(a * b);
+  }
+
+  /**
+   * Modular exponentiation: base^exp mod prime.
+   * Uses square-and-multiply for O(log exp) complexity.
+   */
+  pow(base: bigint, exp: bigint): bigint {
+    let result = 1n;
+    base = this.mod(base);
+
+    while (exp > 0n) {
+      if (exp & 1n) {
+        result = this.mod(result * base);
+      }
+      exp >>= 1n;
+      base = this.mod(base * base);
+    }
+
+    return result;
+  }
+
+  /**
+   * Modular multiplicative inverse: a^(-1) mod prime.
+   * Uses Fermat's little theorem: a^(-1) = a^(p-2) mod p.
+   */
+  inverse(a: bigint): bigint {
+    if (this.mod(a) === 0n) {
+      throw new Error("Cannot compute inverse of zero");
+    }
+    return this.pow(a, this.prime - 2n);
+  }
+
+  /**
+   * Modular division: a / b mod prime = a * b^(-1) mod prime.
+   */
+  div(a: bigint, b: bigint): bigint {
+    return this.mul(a, this.inverse(b));
+  }
+
+  /**
+   * Generate a random field element in [1, prime).
+   * Uses cryptographically secure random bytes.
+   */
+  random(): bigint {
+    // Generate enough bytes to cover the prime
+    const byteLength = Math.ceil(this.prime.toString(2).length / 8);
+    let value: bigint;
+
+    // Rejection sampling to ensure uniform distribution
+    do {
+      const bytes = randomBytes(byteLength);
+      value = BigInt("0x" + bytes.toString("hex"));
+    } while (value >= this.prime || value === 0n);
+
+    return value;
+  }
+
+  /**
+   * Convert a number to a field element.
+   * Throws if the number is outside the valid range.
+   */
+  fromNumber(n: number): bigint {
+    if (!Number.isInteger(n) || n < 0) {
+      throw new Error("Field element must be a non-negative integer");
+    }
+
+    const value = BigInt(n);
+    if (value >= this.prime) {
+      throw new Error(`Value ${n} exceeds field prime ${this.prime}`);
+    }
+
+    return value;
+  }
+
+  /**
+   * Convert a field element to a number.
+   * Throws if the value exceeds JS safe integer range.
+   */
+  toNumber(value: bigint): number {
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new Error(
+        `Field element ${value} exceeds JS safe integer range. ` +
+          `Use bigint operations directly for production field.`,
+      );
+    }
+    return Number(value);
+  }
+
+  /**
+   * Check if this is a production-grade field.
+   */
+  isProductionSecure(): boolean {
+    return this.mode === "production";
+  }
+
+  /**
+   * Get the security level in bits.
+   * Demo mode: ~31 bits (insecure)
+   * Production mode: ~128 bits (secure)
+   */
+  getSecurityBits(): number {
+    return this.mode === "production" ? 128 : 31;
+  }
+}
+
+/**
+ * Singleton instances for common use cases.
+ */
+export const demoField = new FieldArithmetic({
+  mode: "demo",
+  prime: DEMO_PRIME,
+});
+export const productionField = new FieldArithmetic({
+  mode: "production",
+  prime: PRODUCTION_PRIME,
+});

--- a/modules/mpc/src/index.ts
+++ b/modules/mpc/src/index.ts
@@ -2,6 +2,17 @@ import { randomBytes, randomInt } from "node:crypto";
 
 import { commitShare, sha256hex } from "./crypto";
 
+// Re-export field arithmetic for advanced use cases
+export {
+  FieldArithmetic,
+  getFieldConfig,
+  DEMO_PRIME,
+  PRODUCTION_PRIME,
+  demoField,
+  productionField,
+} from "./field";
+export type { FieldConfig, FieldMode } from "./field";
+
 export interface PartyConfig {
   id: string;
   name: string;
@@ -291,3 +302,10 @@ export type {
   DsaAuditRecord,
   MlDsaParams,
 } from "./dsa";
+export { QuantumResistantVault } from "./quantum";
+export type {
+  ThresholdShare,
+  HashLadderKey,
+  QuantumResistantAnchor,
+  VaultConfig,
+} from "./quantum";

--- a/modules/mpc/src/quantum.ts
+++ b/modules/mpc/src/quantum.ts
@@ -1,11 +1,20 @@
-import { randomBytes, randomInt } from "node:crypto";
+import { randomBytes } from "node:crypto";
 
 import { commitShare, sha256hex } from "./crypto";
+import {
+  FieldArithmetic,
+  getFieldConfig,
+  type FieldConfig,
+  type FieldMode,
+} from "./field";
 
 export interface ThresholdShare {
   partyId: string;
   shareIndex: number;
-  value: number;
+  /** Share value as bigint for production mode compatibility. */
+  value: bigint;
+  /** Legacy number value for backward compatibility (demo mode only). */
+  valueNumber?: number | undefined;
   nonce: string;
   commitment: string;
 }
@@ -24,19 +33,54 @@ export interface QuantumResistantAnchor {
   scheme: "hash-ladder";
 }
 
-// Mersenne prime 2^31 − 1.  Large enough for the demo secrets used in
-// examples while keeping share values within safe-integer range.
-// For production Shamir SSS protecting key material, use a prime at least as
-// large as the secret space: 2^127 − 1 or 2^255 − 19 for 128/256-bit security.
-const PRIME = 2_147_483_647n;
+export interface VaultConfig {
+  /** Field mode: "demo" (default) or "production". */
+  fieldMode?: FieldMode;
+}
 
+/**
+ * Quantum-resistant secret sharing vault using Shamir's Secret Sharing.
+ *
+ * Supports two field sizes:
+ * - Demo mode (default): 2^31-1 prime, fast but NOT secure for production
+ * - Production mode: 256-bit prime, cryptographically secure
+ *
+ * Set MPC_FIELD_MODE=production or pass { fieldMode: "production" } for
+ * production deployments.
+ *
+ * @see skills/mpc-secret-sharing.md for security guidance
+ */
 export class QuantumResistantVault {
+  private readonly field: FieldArithmetic;
+
+  constructor(config?: VaultConfig) {
+    const fieldConfig = getFieldConfig(config?.fieldMode);
+    this.field = new FieldArithmetic(fieldConfig);
+  }
+
+  /**
+   * Get the current field configuration.
+   */
+  getFieldConfig(): FieldConfig {
+    return { mode: this.field.mode, prime: this.field.prime };
+  }
+
+  /**
+   * Check if the vault is configured for production-grade security.
+   */
+  isProductionSecure(): boolean {
+    return this.field.isProductionSecure();
+  }
   /**
    * Distribute `secret` across `parties` using Shamir's Secret Sharing.
    * Any `threshold` shares reconstruct the secret; fewer reveal nothing.
+   *
+   * @param secret - The secret to share (must be within field range)
+   * @param parties - Party identifiers to receive shares
+   * @param threshold - Minimum shares needed for reconstruction
    */
   distributeSecret(
-    secret: number,
+    secret: number | bigint,
     parties: string[],
     threshold: number,
   ): Map<string, ThresholdShare> {
@@ -46,27 +90,37 @@ export class QuantumResistantVault {
     if (threshold > parties.length) {
       throw new Error("Threshold cannot exceed party count");
     }
-    if (secret < 0 || secret >= Number(PRIME)) {
-      throw new Error(`Secret must be in range [0, ${PRIME})`);
+
+    const secretBigint = BigInt(secret);
+    if (secretBigint < 0n || secretBigint >= this.field.prime) {
+      throw new Error(
+        `Secret must be in range [0, ${this.field.prime}). ` +
+          `Current field mode: ${this.field.mode}`,
+      );
     }
 
     // Random polynomial of degree (threshold − 1) with secret as constant term.
-    const coeffs: bigint[] = [BigInt(secret)];
+    const coeffs: bigint[] = [secretBigint];
     for (let i = 1; i < threshold; i++) {
-      coeffs.push(BigInt(randomInt(1, Number(PRIME))));
+      coeffs.push(this.field.random());
     }
 
     const shares = new Map<string, ThresholdShare>();
     for (let i = 0; i < parties.length; i++) {
       const x = BigInt(i + 1);
-      const y = Number(this.evalPoly(coeffs, x));
+      const y = this.evalPoly(coeffs, x);
       const nonce = randomBytes(16).toString("hex");
+
+      // For commitment, use number if in demo mode for backward compatibility
+      const commitValue = this.field.mode === "demo" ? Number(y) : y;
+
       shares.set(parties[i]!, {
         partyId: parties[i]!,
         shareIndex: i,
         value: y,
+        valueNumber: this.field.mode === "demo" ? Number(y) : undefined,
         nonce,
-        commitment: commitShare(parties[i]!, i, y, nonce),
+        commitment: commitShare(parties[i]!, i, commitValue, nonce),
       });
     }
 
@@ -76,11 +130,14 @@ export class QuantumResistantVault {
   /**
    * Reconstruct the secret from a set of shares via Lagrange interpolation.
    * Returns `null` when fewer than `threshold` shares are supplied.
+   *
+   * @returns The reconstructed secret as bigint, or null if insufficient shares.
+   *          In demo mode, also returns as number for backward compatibility.
    */
   reconstructSecret(
     shares: ThresholdShare[],
     threshold: number,
-  ): number | null {
+  ): number | bigint | null {
     if (shares.length < threshold) {
       return null;
     }
@@ -90,7 +147,37 @@ export class QuantumResistantVault {
       BigInt(s.value),
     ]);
 
-    return Number(this.lagrangeInterpolate(points));
+    const result = this.lagrangeInterpolate(points);
+
+    // Return number for backward compatibility in demo mode
+    if (
+      this.field.mode === "demo" &&
+      result <= BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      return Number(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Reconstruct the secret and always return as bigint.
+   * Use this for production mode or when bigint precision is required.
+   */
+  reconstructSecretBigint(
+    shares: ThresholdShare[],
+    threshold: number,
+  ): bigint | null {
+    if (shares.length < threshold) {
+      return null;
+    }
+
+    const points: [bigint, bigint][] = shares.map((s) => [
+      BigInt(s.shareIndex + 1),
+      BigInt(s.value),
+    ]);
+
+    return this.lagrangeInterpolate(points);
   }
 
   /** Build a SHA-256 hash chain of `depth` iterations from a random seed. */
@@ -117,14 +204,14 @@ export class QuantumResistantVault {
     };
   }
 
-  // --- Shamir arithmetic over GF(PRIME) ---
+  // --- Shamir arithmetic using configurable field ---
 
   private evalPoly(coeffs: bigint[], x: bigint): bigint {
     let result = 0n;
     let power = 1n;
     for (const c of coeffs) {
-      result = this.mod(result + c * power);
-      power = this.mod(power * x);
+      result = this.field.add(result, this.field.mul(c, power));
+      power = this.field.mul(power, x);
     }
     return result;
   }
@@ -138,28 +225,14 @@ export class QuantumResistantVault {
       for (let j = 0; j < points.length; j++) {
         if (i === j) continue;
         const xj = points[j]![0];
-        num = this.mod(num * this.mod(-xj));
-        den = this.mod(den * this.mod(xi - xj));
+        num = this.field.mul(num, this.field.mod(-xj));
+        den = this.field.mul(den, this.field.sub(xi, xj));
       }
-      const inv = this.modPow(den, PRIME - 2n);
-      result = this.mod(result + this.mod(yi * this.mod(num * inv)));
-    }
-    return result;
-  }
-
-  private mod(a: bigint): bigint {
-    return ((a % PRIME) + PRIME) % PRIME;
-  }
-
-  private modPow(base: bigint, exp: bigint): bigint {
-    let result = 1n;
-    base = this.mod(base);
-    while (exp > 0n) {
-      if (exp & 1n) {
-        result = this.mod(result * base);
-      }
-      exp >>= 1n;
-      base = this.mod(base * base);
+      const inv = this.field.inverse(den);
+      result = this.field.add(
+        result,
+        this.field.mul(yi, this.field.mul(num, inv)),
+      );
     }
     return result;
   }

--- a/modules/shared/src/commit.ts
+++ b/modules/shared/src/commit.ts
@@ -1,10 +1,22 @@
 import { sha256hex } from "./crypto";
 
+/**
+ * Create a cryptographic commitment for a secret share.
+ * The commitment binds the share value to a specific party and index,
+ * preventing substitution attacks.
+ *
+ * @param partyId - Identifier of the share holder
+ * @param index - Share index in the polynomial evaluation
+ * @param value - Share value (number for demo mode, bigint for production)
+ * @param nonce - Random nonce for hiding the value
+ */
 export function commitShare(
   partyId: string,
   index: number,
-  value: number,
+  value: number | bigint,
   nonce: string,
 ): string {
-  return sha256hex(`${nonce}:${partyId}:${index}:${value}`);
+  // Convert bigint to string for consistent hashing
+  const valueStr = typeof value === "bigint" ? value.toString() : String(value);
+  return sha256hex(`${nonce}:${partyId}:${index}:${valueStr}`);
 }


### PR DESCRIPTION
## Summary

Addresses the security warning in `skills/mpc-secret-sharing.md`:

> "Field size < 2^128 allows brute-force enumeration. Current implementation uses 2^31-1 for demo; production needs 256-bit prime."

This PR adds production-grade field arithmetic for Shamir Secret Sharing.

## Changes

### New: `modules/mpc/src/field.ts`
- `DEMO_PRIME` (2^31-1) - Backward compatible, fast, NOT secure
- `PRODUCTION_PRIME` (secp256k1 order) - 256-bit, cryptographically secure
- `FieldArithmetic` class with mod, add, sub, mul, pow, inverse operations
- `MPC_FIELD_MODE` env var support ("demo" | "production")

### Updated: `modules/mpc/src/quantum.ts`
- `QuantumResistantVault` now accepts `VaultConfig` with `fieldMode` option
- `distributeSecret` works with both number and bigint secrets
- `reconstructSecret` returns appropriate type based on field mode
- New `reconstructSecretBigint` method for explicit bigint handling

### Updated: `modules/shared/src/commit.ts`
- `commitShare` now accepts `number | bigint` values

## Usage

```typescript
// Demo mode (default, backward compatible)
const vault = new QuantumResistantVault();

// Production mode (secure)
const secureVault = new QuantumResistantVault({ fieldMode: "production" });

// Or via environment
// MPC_FIELD_MODE=production
```

## Test plan

- [ ] All 129 TypeScript tests pass
- [ ] All examples run successfully
- [ ] Field arithmetic is correct for both primes
- [ ] Backward compatibility maintained

Closes #60