### PR TITLE
test: add property-based fuzz tests for crypto modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/node": "^22.13.10",
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.6.0",
         "globals": "^17.4.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -1183,6 +1184,7 @@
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1201,6 +1203,7 @@
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1214,6 +1217,7 @@
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1226,7 +1230,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
@@ -1234,6 +1239,7 @@
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1252,6 +1258,7 @@
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.2.2"
       },
@@ -1268,6 +1275,7 @@
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1286,6 +1294,7 @@
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1379,6 +1388,7 @@
       "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -1396,6 +1406,7 @@
       "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2517,6 +2528,7 @@
       "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -2849,6 +2861,7 @@
       "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -2906,6 +2919,7 @@
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -3500,7 +3514,8 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3697,7 +3712,8 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -4088,7 +4104,8 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4097,6 +4114,29 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
     },
     "node_modules/fast-content-type-parse": {
       "version": "3.0.0",
@@ -4295,6 +4335,7 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4379,6 +4420,7 @@
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4509,6 +4551,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4542,7 +4585,8 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -4550,6 +4594,7 @@
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4560,6 +4605,7 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -4695,7 +4741,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -4922,6 +4969,7 @@
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5061,6 +5109,7 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -5653,6 +5702,7 @@
       "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -5853,6 +5903,7 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5863,6 +5914,7 @@
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -5876,6 +5928,7 @@
       "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -5894,6 +5947,7 @@
       "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5907,6 +5961,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5919,7 +5974,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -5927,6 +5983,7 @@
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5940,6 +5997,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5952,7 +6010,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
@@ -5960,6 +6019,7 @@
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5973,6 +6033,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5985,7 +6046,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
@@ -5993,6 +6055,7 @@
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -6096,6 +6159,7 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6150,6 +6214,7 @@
       "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -6175,6 +6240,7 @@
       "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -6185,6 +6251,7 @@
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -6201,6 +6268,7 @@
       "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -8966,7 +9034,8 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/packageurl-js": {
       "version": "2.0.1",
@@ -9070,6 +9139,7 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -9290,6 +9360,7 @@
       "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -9307,6 +9378,7 @@
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -9367,6 +9439,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/railroad-diagrams": {
       "version": "1.0.0",
@@ -9600,6 +9689,7 @@
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10213,6 +10303,7 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -10238,6 +10329,7 @@
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -10253,6 +10345,7 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -10342,6 +10435,7 @@
       "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -10435,6 +10529,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10463,6 +10558,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10554,6 +10650,7 @@
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -10962,6 +11059,7 @@
       "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -10975,6 +11073,7 @@
       "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -11128,6 +11227,7 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -11210,6 +11310,7 @@
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/node": "^22.13.10",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.6.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/tests/hsm.property.test.ts
+++ b/tests/hsm.property.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Property-based fuzz tests for HSM cryptographic modules.
+ *
+ * Tests envelope encryption round-trip properties and key management invariants.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { HsmClient } from "../modules/hsm/src/index";
+
+// Helper to create an initialized HSM client
+function createHsm(slotId = "test-slot"): HsmClient {
+  const hsm = new HsmClient();
+  hsm.initialize({ slotId, label: "Property Test HSM" });
+  return hsm;
+}
+
+// ── Envelope Encryption Properties ──────────────────────────────────────────
+
+test("envelope encryption: round-trip preserves plaintext", () => {
+  const hsm = createHsm("roundtrip-slot");
+  const kekLabel = "test-roundtrip-kek";
+  hsm.generateSymmetricKey(kekLabel);
+
+  fc.assert(
+    fc.property(fc.string({ minLength: 1, maxLength: 10000 }), (plaintext) => {
+      const { encryptedRecord, wrappedDek } = hsm.encryptWithEnvelope(
+        kekLabel,
+        plaintext,
+      );
+      const decrypted = hsm.decryptWithEnvelope(wrappedDek, encryptedRecord);
+      return decrypted === plaintext;
+    }),
+    { numRuns: 100 },
+  );
+});
+
+test("envelope encryption: different plaintexts produce different ciphertexts", () => {
+  const hsm = createHsm("diff-slot");
+  const kekLabel = "test-diff-kek";
+  hsm.generateSymmetricKey(kekLabel);
+
+  fc.assert(
+    fc.property(
+      fc.string({ minLength: 1, maxLength: 1000 }),
+      fc.string({ minLength: 1, maxLength: 1000 }),
+      (plaintext1, plaintext2) => {
+        if (plaintext1 === plaintext2) return true; // Skip identical inputs
+
+        const result1 = hsm.encryptWithEnvelope(kekLabel, plaintext1);
+        const result2 = hsm.encryptWithEnvelope(kekLabel, plaintext2);
+
+        // Ciphertexts should be different
+        return (
+          result1.encryptedRecord.ciphertext !==
+          result2.encryptedRecord.ciphertext
+        );
+      },
+    ),
+    { numRuns: 50 },
+  );
+});
+
+test("envelope encryption: same plaintext with different DEKs produces different ciphertexts", () => {
+  const hsm = createHsm("iv-slot");
+  const kekLabel = "test-iv-kek";
+  hsm.generateSymmetricKey(kekLabel);
+
+  fc.assert(
+    fc.property(fc.string({ minLength: 1, maxLength: 1000 }), (plaintext) => {
+      const result1 = hsm.encryptWithEnvelope(kekLabel, plaintext);
+      const result2 = hsm.encryptWithEnvelope(kekLabel, plaintext);
+
+      // IVs should be different (random)
+      assert.notEqual(result1.encryptedRecord.iv, result2.encryptedRecord.iv);
+
+      // Ciphertexts should be different due to different DEKs
+      assert.notEqual(
+        result1.encryptedRecord.ciphertext,
+        result2.encryptedRecord.ciphertext,
+      );
+
+      // But both should decrypt to same plaintext
+      const decrypted1 = hsm.decryptWithEnvelope(
+        result1.wrappedDek,
+        result1.encryptedRecord,
+      );
+      const decrypted2 = hsm.decryptWithEnvelope(
+        result2.wrappedDek,
+        result2.encryptedRecord,
+      );
+      return decrypted1 === plaintext && decrypted2 === plaintext;
+    }),
+    { numRuns: 50 },
+  );
+});
+
+// ── Asymmetric Signing Properties ───────────────────────────────────────────
+
+test("ECDSA: sign-verify round-trip succeeds for valid signatures", () => {
+  const hsm = createHsm("sign-slot");
+  const keyLabel = "test-sign-key";
+  hsm.generateKeyPair(keyLabel);
+
+  fc.assert(
+    fc.property(fc.string({ minLength: 1, maxLength: 10000 }), (message) => {
+      const { signature } = hsm.sign(keyLabel, message);
+      const isValid = hsm.verify(keyLabel, message, signature);
+      return isValid === true;
+    }),
+    { numRuns: 100 },
+  );
+});
+
+test("ECDSA: different messages produce different signatures", () => {
+  const hsm = createHsm("diff-sign-slot");
+  const keyLabel = "test-diff-sign-key";
+  hsm.generateKeyPair(keyLabel);
+
+  fc.assert(
+    fc.property(
+      fc.string({ minLength: 1, maxLength: 1000 }),
+      fc.string({ minLength: 1, maxLength: 1000 }),
+      (message1, message2) => {
+        if (message1 === message2) return true; // Skip identical inputs
+
+        const { signature: sig1 } = hsm.sign(keyLabel, message1);
+        const { signature: sig2 } = hsm.sign(keyLabel, message2);
+
+        // Signatures should be different for different messages
+        return sig1 !== sig2;
+      },
+    ),
+    { numRuns: 50 },
+  );
+});
+
+test("ECDSA: tampered message fails verification", () => {
+  const hsm = createHsm("tamper-slot");
+  const keyLabel = "test-tamper-key";
+  hsm.generateKeyPair(keyLabel);
+
+  fc.assert(
+    fc.property(
+      fc.string({ minLength: 2, maxLength: 1000 }),
+      fc.integer({ min: 0, max: 100 }),
+      (message, tamperPos) => {
+        const { signature } = hsm.sign(keyLabel, message);
+
+        // Tamper with the message
+        const pos = tamperPos % message.length;
+        const tamperedChar = message[pos] === "x" ? "y" : "x";
+        const tamperedMessage =
+          message.slice(0, pos) + tamperedChar + message.slice(pos + 1);
+
+        if (tamperedMessage === message) return true; // Skip if tamper had no effect
+
+        const isValid = hsm.verify(keyLabel, tamperedMessage, signature);
+        return isValid === false;
+      },
+    ),
+    { numRuns: 50 },
+  );
+});
+
+// ── Key Management Properties ───────────────────────────────────────────────
+
+test("key generation: each KEK produces usable envelope encryption", () => {
+  fc.assert(
+    fc.property(
+      fc.array(
+        fc
+          .string({ minLength: 1, maxLength: 50 })
+          .filter((s) => /^[a-z0-9-]+$/i.test(s)),
+        { minLength: 1, maxLength: 5 },
+      ),
+      (labels) => {
+        const hsm = createHsm(
+          "keygen-slot-" + Math.random().toString(36).slice(2),
+        );
+        const uniqueLabels = [...new Set(labels)];
+
+        for (const label of uniqueLabels) {
+          hsm.generateSymmetricKey(label);
+        }
+
+        // All keys should be usable for envelope encryption
+        for (const label of uniqueLabels) {
+          const { encryptedRecord, wrappedDek } = hsm.encryptWithEnvelope(
+            label,
+            "test-data",
+          );
+          assert.ok(encryptedRecord.ciphertext.length > 0);
+          assert.ok(wrappedDek.wrappedDek.length > 0);
+        }
+
+        return true;
+      },
+    ),
+    { numRuns: 20 },
+  );
+});
+
+// ── Wrapped DEK Properties ──────────────────────────────────────────────────
+
+test("envelope encryption: each envelope has unique wrapped DEK", () => {
+  const hsm = createHsm("unique-dek-slot");
+  const kekLabel = "test-unique-dek";
+  hsm.generateSymmetricKey(kekLabel);
+
+  fc.assert(
+    fc.property(fc.string({ minLength: 1, maxLength: 1000 }), (plaintext) => {
+      const result1 = hsm.encryptWithEnvelope(kekLabel, plaintext);
+      const result2 = hsm.encryptWithEnvelope(kekLabel, plaintext);
+
+      // Each encryption should use a different DEK
+      assert.notEqual(
+        result1.wrappedDek.wrappedDek,
+        result2.wrappedDek.wrappedDek,
+      );
+
+      // Both should decrypt correctly
+      const decrypted1 = hsm.decryptWithEnvelope(
+        result1.wrappedDek,
+        result1.encryptedRecord,
+      );
+      const decrypted2 = hsm.decryptWithEnvelope(
+        result2.wrappedDek,
+        result2.encryptedRecord,
+      );
+
+      return decrypted1 === plaintext && decrypted2 === plaintext;
+    }),
+    { numRuns: 30 },
+  );
+});
+
+// ── Audit Log Properties ────────────────────────────────────────────────────
+
+test("audit log: all operations are recorded", () => {
+  const hsm = createHsm("audit-slot");
+  const kekLabel = "test-audit-kek";
+  const keyPairLabel = "test-audit-keypair";
+
+  // Perform various operations
+  hsm.generateSymmetricKey(kekLabel);
+  hsm.generateKeyPair(keyPairLabel);
+  hsm.encryptWithEnvelope(kekLabel, "test-data");
+  hsm.sign(keyPairLabel, "test-message");
+
+  const auditLog = hsm.getAuditLog();
+
+  // Should have at least: initialize, generateSymmetricKey, generateKeyPair,
+  // encryptWithEnvelope (wrapKey), sign
+  assert.ok(auditLog.length >= 5);
+
+  // All entries should have timestamps
+  for (const entry of auditLog) {
+    assert.ok(entry.timestamp.length > 0);
+    assert.ok(entry.operation.length > 0);
+  }
+});

--- a/tests/kyber.property.test.ts
+++ b/tests/kyber.property.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Property-based fuzz tests for post-quantum cryptographic modules.
+ *
+ * Tests ML-KEM (Kyber) and Hybrid KEM round-trip properties.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { KyberKem, HybridKem, ML_KEM_SIZES } from "../modules/mpc/src/index";
+
+// Default parameter set for most tests
+const DEFAULT_PARAMS = "ml-kem-768" as const;
+
+// ── ML-KEM (Kyber) Properties ───────────────────────────────────────────────
+
+test("ML-KEM: encapsulate/decapsulate produces identical shared secrets", () => {
+  const kem = new KyberKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      // Generate fresh key pair for each test
+      const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+
+      // Encapsulate
+      const encapsulation = kem.encapsulate(keyPair.publicKey, DEFAULT_PARAMS);
+
+      // Decapsulate
+      const sharedSecret = kem.decapsulate(
+        encapsulation.ciphertext,
+        keyPair.secretKey,
+        DEFAULT_PARAMS,
+      );
+
+      // Shared secrets must match
+      assert.equal(encapsulation.sharedSecret.length, sharedSecret.length);
+
+      // Compare byte-by-byte
+      for (let i = 0; i < encapsulation.sharedSecret.length; i++) {
+        if (encapsulation.sharedSecret[i] !== sharedSecret[i]) {
+          return false;
+        }
+      }
+
+      return true;
+    }),
+    { numRuns: 20 }, // Fewer runs due to expensive PQ crypto
+  );
+});
+
+test("ML-KEM: different key pairs produce different shared secrets", () => {
+  const kem = new KyberKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPair1 = kem.generateKeyPair(DEFAULT_PARAMS);
+      const keyPair2 = kem.generateKeyPair(DEFAULT_PARAMS);
+
+      // Encapsulate to both public keys
+      const encap1 = kem.encapsulate(keyPair1.publicKey, DEFAULT_PARAMS);
+      const encap2 = kem.encapsulate(keyPair2.publicKey, DEFAULT_PARAMS);
+
+      // Shared secrets should be different (with overwhelming probability)
+      let same = true;
+      for (let i = 0; i < encap1.sharedSecret.length && same; i++) {
+        if (encap1.sharedSecret[i] !== encap2.sharedSecret[i]) {
+          same = false;
+        }
+      }
+
+      return !same; // Should be different
+    }),
+    { numRuns: 10 },
+  );
+});
+
+test("ML-KEM: wrong secret key fails to decrypt", () => {
+  const kem = new KyberKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPair1 = kem.generateKeyPair(DEFAULT_PARAMS);
+      const keyPair2 = kem.generateKeyPair(DEFAULT_PARAMS);
+
+      // Encapsulate to keyPair1's public key
+      const encapsulation = kem.encapsulate(keyPair1.publicKey, DEFAULT_PARAMS);
+
+      // Try to decapsulate with keyPair2's secret key (wrong key)
+      const wrongDecap = kem.decapsulate(
+        encapsulation.ciphertext,
+        keyPair2.secretKey,
+        DEFAULT_PARAMS,
+      );
+
+      // Should produce different shared secret (implicit rejection)
+      let same = true;
+      for (let i = 0; i < encapsulation.sharedSecret.length && same; i++) {
+        if (encapsulation.sharedSecret[i] !== wrongDecap[i]) {
+          same = false;
+        }
+      }
+
+      return !same; // Should be different due to wrong key
+    }),
+    { numRuns: 10 },
+  );
+});
+
+// ── Hybrid KEM Properties ───────────────────────────────────────────────────
+
+test("Hybrid KEM: encapsulate/decapsulate produces identical combined keys", () => {
+  const hybridKem = new HybridKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      // Generate hybrid key pairs
+      const keyPairs = hybridKem.generateKeyPairs();
+
+      // Encapsulate
+      const encapsulation = hybridKem.encapsulate(
+        keyPairs.x25519.publicKey,
+        keyPairs.kyber.publicKey,
+      );
+
+      // Decapsulate
+      const decapsulation = hybridKem.decapsulate(
+        keyPairs.x25519.privateKey,
+        keyPairs.kyber.secretKey,
+        encapsulation.x25519EphemeralPublicKeyDer,
+        encapsulation.kyberCiphertext,
+      );
+
+      // Combined keys must match
+      assert.equal(
+        encapsulation.combinedKey.length,
+        decapsulation.combinedKey.length,
+      );
+      assert.equal(encapsulation.combinedKey.length, 32); // 256-bit key
+
+      return encapsulation.combinedKey.equals(decapsulation.combinedKey);
+    }),
+    { numRuns: 15 },
+  );
+});
+
+test("Hybrid KEM: combined key is 256 bits", () => {
+  const hybridKem = new HybridKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPairs = hybridKem.generateKeyPairs();
+      const encapsulation = hybridKem.encapsulate(
+        keyPairs.x25519.publicKey,
+        keyPairs.kyber.publicKey,
+      );
+
+      // Key should be exactly 32 bytes (256 bits)
+      return encapsulation.combinedKey.length === 32;
+    }),
+    { numRuns: 10 },
+  );
+});
+
+test("Hybrid KEM: audit commitment is deterministic", () => {
+  const hybridKem = new HybridKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPairs = hybridKem.generateKeyPairs();
+      const encapsulation = hybridKem.encapsulate(
+        keyPairs.x25519.publicKey,
+        keyPairs.kyber.publicKey,
+      );
+
+      // Audit commitment should be a SHA-256 hash (64 hex chars)
+      assert.equal(encapsulation.auditCommitment.length, 64);
+      assert.match(encapsulation.auditCommitment, /^[a-f0-9]{64}$/);
+
+      return true;
+    }),
+    { numRuns: 10 },
+  );
+});
+
+test("Hybrid KEM: wrong X25519 key fails decapsulation", () => {
+  const hybridKem = new HybridKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPairs1 = hybridKem.generateKeyPairs();
+      const keyPairs2 = hybridKem.generateKeyPairs();
+
+      // Encapsulate to keyPairs1
+      const encapsulation = hybridKem.encapsulate(
+        keyPairs1.x25519.publicKey,
+        keyPairs1.kyber.publicKey,
+      );
+
+      // Decapsulate with wrong X25519 key (keyPairs2)
+      const wrongDecap = hybridKem.decapsulate(
+        keyPairs2.x25519.privateKey, // Wrong X25519 key
+        keyPairs1.kyber.secretKey, // Correct Kyber key
+        encapsulation.x25519EphemeralPublicKeyDer,
+        encapsulation.kyberCiphertext,
+      );
+
+      // Combined keys should be different
+      return !encapsulation.combinedKey.equals(wrongDecap.combinedKey);
+    }),
+    { numRuns: 10 },
+  );
+});
+
+test("Hybrid KEM: wrong Kyber key fails decapsulation", () => {
+  const hybridKem = new HybridKem();
+
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const keyPairs1 = hybridKem.generateKeyPairs();
+      const keyPairs2 = hybridKem.generateKeyPairs();
+
+      // Encapsulate to keyPairs1
+      const encapsulation = hybridKem.encapsulate(
+        keyPairs1.x25519.publicKey,
+        keyPairs1.kyber.publicKey,
+      );
+
+      // Decapsulate with wrong Kyber key (keyPairs2)
+      const wrongDecap = hybridKem.decapsulate(
+        keyPairs1.x25519.privateKey, // Correct X25519 key
+        keyPairs2.kyber.secretKey, // Wrong Kyber key
+        encapsulation.x25519EphemeralPublicKeyDer,
+        encapsulation.kyberCiphertext,
+      );
+
+      // Combined keys should be different
+      return !encapsulation.combinedKey.equals(wrongDecap.combinedKey);
+    }),
+    { numRuns: 10 },
+  );
+});
+
+// ── Key Size Properties ─────────────────────────────────────────────────────
+
+test("ML-KEM-768: key sizes match NIST specification", () => {
+  const kem = new KyberKem();
+  const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+
+  // ML-KEM-768 key sizes per FIPS 203
+  assert.equal(
+    keyPair.publicKey.length,
+    ML_KEM_SIZES[DEFAULT_PARAMS].publicKey,
+  );
+  assert.equal(
+    keyPair.secretKey.length,
+    ML_KEM_SIZES[DEFAULT_PARAMS].secretKey,
+  );
+  assert.equal(keyPair.params, DEFAULT_PARAMS);
+});
+
+test("ML-KEM-768: ciphertext size matches NIST specification", () => {
+  const kem = new KyberKem();
+  const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+  const encapsulation = kem.encapsulate(keyPair.publicKey, DEFAULT_PARAMS);
+
+  // ML-KEM-768 ciphertext size per FIPS 203
+  assert.equal(
+    encapsulation.ciphertext.length,
+    ML_KEM_SIZES[DEFAULT_PARAMS].ciphertext,
+  );
+  assert.equal(
+    encapsulation.sharedSecret.length,
+    ML_KEM_SIZES[DEFAULT_PARAMS].sharedSecret,
+  );
+});
+
+// ── AES Key Derivation Properties ───────────────────────────────────────────
+
+test("ML-KEM: deriveAesKey produces 32-byte key", () => {
+  const kem = new KyberKem();
+  const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+  const encapsulation = kem.encapsulate(keyPair.publicKey, DEFAULT_PARAMS);
+
+  const aesKey = kem.deriveAesKey(encapsulation.sharedSecret);
+
+  assert.equal(aesKey.length, 32); // AES-256
+});
+
+test("ML-KEM: same shared secret with same info produces same AES key", () => {
+  const kem = new KyberKem();
+  const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+  const encapsulation = kem.encapsulate(keyPair.publicKey, DEFAULT_PARAMS);
+
+  const aesKey1 = kem.deriveAesKey(encapsulation.sharedSecret, "context-v1");
+  const aesKey2 = kem.deriveAesKey(encapsulation.sharedSecret, "context-v1");
+
+  assert.ok(aesKey1.equals(aesKey2));
+});
+
+test("ML-KEM: different info strings produce different AES keys", () => {
+  const kem = new KyberKem();
+  const keyPair = kem.generateKeyPair(DEFAULT_PARAMS);
+  const encapsulation = kem.encapsulate(keyPair.publicKey, DEFAULT_PARAMS);
+
+  const aesKey1 = kem.deriveAesKey(encapsulation.sharedSecret, "context-v1");
+  const aesKey2 = kem.deriveAesKey(encapsulation.sharedSecret, "context-v2");
+
+  assert.ok(!aesKey1.equals(aesKey2));
+});

--- a/tests/mpc.property.test.ts
+++ b/tests/mpc.property.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Property-based fuzz tests for MPC cryptographic modules.
+ *
+ * Uses fast-check for exhaustive edge case coverage that unit tests miss.
+ * Cryptographic implementations require property-based testing because
+ * off-by-one errors in field arithmetic cause silent security failures.
+ *
+ * @see https://github.com/dubzzz/fast-check
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import {
+  MPCEngine,
+  QuantumResistantVault,
+  FieldArithmetic,
+  DEMO_PRIME,
+  PRODUCTION_PRIME,
+} from "../modules/mpc/src/index";
+
+// ── Field Arithmetic Properties ─────────────────────────────────────────────
+
+test("field arithmetic: addition is commutative", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      (a, b) => {
+        return field.add(a, b) === field.add(b, a);
+      },
+    ),
+    { numRuns: 1000 },
+  );
+});
+
+test("field arithmetic: multiplication is commutative", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      (a, b) => {
+        return field.mul(a, b) === field.mul(b, a);
+      },
+    ),
+    { numRuns: 1000 },
+  );
+});
+
+test("field arithmetic: a * inverse(a) = 1 for non-zero a", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(fc.bigInt({ min: 1n, max: DEMO_PRIME - 1n }), (a) => {
+      const inv = field.inverse(a);
+      return field.mul(a, inv) === 1n;
+    }),
+    { numRuns: 500 },
+  );
+});
+
+test("field arithmetic: (a + b) - b = a", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }),
+      (a, b) => {
+        return field.sub(field.add(a, b), b) === a;
+      },
+    ),
+    { numRuns: 1000 },
+  );
+});
+
+test("field arithmetic: pow(a, 0) = 1 for any a", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(fc.bigInt({ min: 1n, max: DEMO_PRIME - 1n }), (a) => {
+      return field.pow(a, 0n) === 1n;
+    }),
+    { numRuns: 500 },
+  );
+});
+
+test("field arithmetic: pow(a, 1) = a", () => {
+  const field = new FieldArithmetic({ mode: "demo", prime: DEMO_PRIME });
+
+  fc.assert(
+    fc.property(fc.bigInt({ min: 0n, max: DEMO_PRIME - 1n }), (a) => {
+      return field.pow(a, 1n) === a;
+    }),
+    { numRuns: 500 },
+  );
+});
+
+// ── Additive Secret Sharing Properties ──────────────────────────────────────
+
+test("MPC additive sharing: shares reconstruct original secret", () => {
+  const engine = new MPCEngine();
+  engine.registerParty({ id: "p1", name: "Party 1", endpoint: "http://p1" });
+  engine.registerParty({ id: "p2", name: "Party 2", endpoint: "http://p2" });
+  engine.registerParty({ id: "p3", name: "Party 3", endpoint: "http://p3" });
+
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 1_000_000 }),
+      fc.uuid(),
+      (secret, computationId) => {
+        const shares = engine.splitSecret(secret, ["p1", "p2", "p3"]);
+        assert.equal(shares.length, 3);
+
+        for (const share of shares) {
+          engine.submitShare(computationId, share);
+        }
+
+        const result = engine.compute(computationId, "sum");
+        return result.aggregate === secret;
+      },
+    ),
+    { numRuns: 100 },
+  );
+});
+
+test("MPC additive sharing: individual shares reveal nothing about secret", () => {
+  const engine = new MPCEngine();
+  engine.registerParty({ id: "p1", name: "Party 1", endpoint: "http://p1" });
+  engine.registerParty({ id: "p2", name: "Party 2", endpoint: "http://p2" });
+
+  // For different secrets, individual share values should be statistically indistinguishable
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 1_000_000 }),
+      fc.integer({ min: 0, max: 1_000_000 }),
+      (secret1, secret2) => {
+        const shares1 = engine.splitSecret(secret1, ["p1", "p2"]);
+        const shares2 = engine.splitSecret(secret2, ["p1", "p2"]);
+
+        // Shares should be different (with high probability) even for same secret
+        // This tests the randomness of share generation
+        if (secret1 === secret2) {
+          // Even same secret should produce different shares due to randomness
+          return (
+            shares1[0]!.value !== shares2[0]!.value ||
+            shares1[1]!.value !== shares2[1]!.value
+          );
+        }
+
+        // For different secrets, we just verify shares exist
+        return shares1.length === 2 && shares2.length === 2;
+      },
+    ),
+    { numRuns: 50 },
+  );
+});
+
+// ── Shamir Threshold Sharing Properties ─────────────────────────────────────
+
+test("Shamir: any k-of-n shares reconstruct the secret", () => {
+  const vault = new QuantumResistantVault({ fieldMode: "demo" });
+
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 1_000_000 }),
+      fc.integer({ min: 3, max: 5 }), // threshold
+      fc.integer({ min: 0, max: 2 }), // extra parties above threshold
+      (secret, threshold, extra) => {
+        const partyCount = threshold + extra;
+        const parties = Array.from(
+          { length: partyCount },
+          (_, i) => `party-${i}`,
+        );
+
+        const shares = vault.distributeSecret(secret, parties, threshold);
+        const shareArray = Array.from(shares.values());
+
+        // Take exactly threshold shares (first k)
+        const subset = shareArray.slice(0, threshold);
+        const reconstructed = vault.reconstructSecret(subset, threshold);
+
+        return reconstructed === secret;
+      },
+    ),
+    { numRuns: 100 },
+  );
+});
+
+test("Shamir: fewer than k shares return null", () => {
+  const vault = new QuantumResistantVault({ fieldMode: "demo" });
+
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 1_000_000 }),
+      fc.integer({ min: 3, max: 5 }),
+      (secret, threshold) => {
+        const parties = Array.from(
+          { length: threshold + 1 },
+          (_, i) => `party-${i}`,
+        );
+        const shares = vault.distributeSecret(secret, parties, threshold);
+        const shareArray = Array.from(shares.values());
+
+        // Take one fewer than threshold
+        const subset = shareArray.slice(0, threshold - 1);
+        const reconstructed = vault.reconstructSecret(subset, threshold);
+
+        return reconstructed === null;
+      },
+    ),
+    { numRuns: 50 },
+  );
+});
+
+test("Shamir: different k-subsets reconstruct same secret", () => {
+  const vault = new QuantumResistantVault({ fieldMode: "demo" });
+
+  fc.assert(
+    fc.property(fc.integer({ min: 1, max: 100_000 }), (secret) => {
+      const threshold = 3;
+      const parties = ["p1", "p2", "p3", "p4", "p5"];
+
+      const shares = vault.distributeSecret(secret, parties, threshold);
+      const shareArray = Array.from(shares.values());
+
+      // Take first 3 shares
+      const subset1 = [shareArray[0]!, shareArray[1]!, shareArray[2]!];
+      const result1 = vault.reconstructSecret(subset1, threshold);
+
+      // Take last 3 shares
+      const subset2 = [shareArray[2]!, shareArray[3]!, shareArray[4]!];
+      const result2 = vault.reconstructSecret(subset2, threshold);
+
+      // Take alternating shares
+      const subset3 = [shareArray[0]!, shareArray[2]!, shareArray[4]!];
+      const result3 = vault.reconstructSecret(subset3, threshold);
+
+      return result1 === secret && result2 === secret && result3 === secret;
+    }),
+    { numRuns: 50 },
+  );
+});
+
+// ── Commitment Integrity Properties ─────────────────────────────────────────
+
+test("commitments: same input produces same commitment", () => {
+  const engine = new MPCEngine();
+  engine.registerParty({ id: "p1", name: "Party 1", endpoint: "http://p1" });
+  engine.registerParty({ id: "p2", name: "Party 2", endpoint: "http://p2" });
+
+  fc.assert(
+    fc.property(fc.integer({ min: 0, max: 1_000_000 }), (secret) => {
+      const shares = engine.splitSecret(secret, ["p1", "p2"]);
+
+      // Verify each share's commitment matches its value
+      for (const share of shares) {
+        // Commitment is already computed, verify it's deterministic
+        assert.equal(typeof share.commitment, "string");
+        assert.equal(share.commitment.length, 64); // SHA-256 hex
+      }
+
+      return true;
+    }),
+    { numRuns: 100 },
+  );
+});
+
+// ── Production Field Properties ─────────────────────────────────────────────
+
+test("production field: basic arithmetic works with 256-bit numbers", () => {
+  const field = new FieldArithmetic({
+    mode: "production",
+    prime: PRODUCTION_PRIME,
+  });
+
+  // Test with large numbers near the prime
+  const a = PRODUCTION_PRIME - 1n;
+  const b = PRODUCTION_PRIME - 2n;
+
+  // a + b should wrap around
+  const sum = field.add(a, b);
+  assert.ok(sum < PRODUCTION_PRIME);
+  assert.ok(sum >= 0n);
+
+  // a * 1 = a
+  assert.equal(field.mul(a, 1n), a);
+
+  // a - a = 0
+  assert.equal(field.sub(a, a), 0n);
+});
+
+test("production field: inverse works for large numbers", () => {
+  const field = new FieldArithmetic({
+    mode: "production",
+    prime: PRODUCTION_PRIME,
+  });
+
+  // Test inverse for a few strategic values
+  const values = [
+    1n,
+    2n,
+    PRODUCTION_PRIME - 1n,
+    PRODUCTION_PRIME / 2n,
+    123456789012345678901234567890n,
+  ];
+
+  for (const v of values) {
+    const inv = field.inverse(v);
+    const product = field.mul(v, inv);
+    assert.equal(product, 1n, `inverse failed for ${v}`);
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `fast-check` property-based testing for cryptographic modules
- HSM: envelope encryption roundtrip, ECDSA sign/verify, key management, audit logging
- ML-KEM (Kyber): encapsulate/decapsulate, NIST FIPS 203 key size validation, hybrid X25519+Kyber KEM
- MPC: field arithmetic (commutativity, inverse), Shamir k-of-n threshold reconstruction, commitment integrity

## Why property tests for crypto

Unit tests cover the cases we think of. Property tests cover the cases we didn't. Crypto bugs are silent - off-by-one in field arithmetic won't throw an error, it'll just produce wrong shares.

## Test plan

- [x] All 165 tests pass locally
- [x] `npm run verify` green
- [ ] CI workflow passes
- [ ] Snyk scan clean

Closes #66, #71, #72, #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)