### PR TITLE
feat(hsm): add persistent audit log adapters for compliance

### DIFF
--- a/docs/architecture/hsm-integration-patterns.md
+++ b/docs/architecture/hsm-integration-patterns.md
@@ -115,6 +115,71 @@ Corda nodes hold a legal-identity key pair registered with the Network Map Servi
 
 The `getAuditLog()` method is the only operation safe to call before `initialize()` (it returns an empty array).
 
+## Audit Log Adapters
+
+The HSM module supports multiple audit log backends for compliance requirements:
+
+### In-Memory (default)
+
+```typescript
+import { InMemoryAuditLog } from "@enterprise-blockchain/hsm";
+const audit = new InMemoryAuditLog();
+```
+
+Suitable for development and testing. Lost on process restart.
+
+### File-based with cryptographic chaining
+
+```typescript
+import { FileAuditLog } from "@enterprise-blockchain/hsm";
+const audit = new FileAuditLog("/var/log/hsm-audit.ndjson");
+
+// Verify integrity of the audit chain
+const { valid, errors } = audit.verifyIntegrity();
+```
+
+Each entry includes:
+
+- SHA-256 hash of the previous entry (tamper-evidence)
+- Monotonic sequence number (gap detection)
+- Entry hash for integrity verification
+
+File format: NDJSON (newline-delimited JSON) for append-only writes.
+
+### Syslog for enterprise SIEM
+
+```typescript
+import { SyslogAuditLog } from "@enterprise-blockchain/hsm";
+const audit = new SyslogAuditLog({
+  host: "siem.corp.example.com",
+  port: 514,
+  facility: "auth",
+  appName: "hsm-audit",
+});
+```
+
+Sends RFC 5424 formatted messages to a syslog server. Includes structured data with operation details and entry hash for correlation.
+
+### Factory with environment configuration
+
+```typescript
+import { AuditLogFactory } from "@enterprise-blockchain/hsm";
+
+// Reads HSM_AUDIT_LOG_TYPE, HSM_AUDIT_LOG_PATH, HSM_SYSLOG_* from env
+const audit = AuditLogFactory.createFromEnv();
+```
+
+Environment variables:
+
+| Variable              | Values                     | Description          |
+| --------------------- | -------------------------- | -------------------- |
+| `HSM_AUDIT_LOG_TYPE`  | `memory`, `file`, `syslog` | Adapter type         |
+| `HSM_AUDIT_LOG_PATH`  | File path                  | For `file` type      |
+| `HSM_SYSLOG_HOST`     | Hostname or IP             | Syslog server        |
+| `HSM_SYSLOG_PORT`     | Port number                | Default: 514         |
+| `HSM_SYSLOG_FACILITY` | RFC 5424 facility name     | Default: `auth`      |
+| `HSM_SYSLOG_APP_NAME` | Application identifier     | Default: `hsm-audit` |
+
 ## When to use HSM vs. other key storage patterns
 
 | Pattern                 | Mechanism                                    | Best for                                                                      |

--- a/modules/hsm/src/index.ts
+++ b/modules/hsm/src/index.ts
@@ -18,6 +18,25 @@ export { EnvelopeEncryptionService } from "./application/envelope-encryption-ser
 // Infrastructure
 export { InMemoryAuditLog } from "./infrastructure/audit-log";
 export { InMemoryKeyStore } from "./infrastructure/key-store";
+export { FileAuditLog } from "./infrastructure/file-audit-log";
+export type { ChainedAuditEntry } from "./infrastructure/file-audit-log";
+export {
+  SyslogAuditLog,
+  DEFAULT_SYSLOG_CONFIG,
+} from "./infrastructure/syslog-audit-log";
+export type {
+  SyslogConfig,
+  SyslogSeverity,
+  SyslogFacility,
+} from "./infrastructure/syslog-audit-log";
+export {
+  AuditLogFactory,
+  AUDIT_LOG_ENV,
+} from "./infrastructure/audit-log-factory";
+export type {
+  AuditLogType,
+  AuditLogFactoryConfig,
+} from "./infrastructure/audit-log-factory";
 
 // ---------------------------------------------------------------------------
 // Facade — preserves the original HsmClient API.

--- a/modules/hsm/src/infrastructure/audit-log-factory.ts
+++ b/modules/hsm/src/infrastructure/audit-log-factory.ts
@@ -1,0 +1,120 @@
+import type { AuditLog } from "../domain/ports";
+import { InMemoryAuditLog } from "./audit-log";
+import { FileAuditLog } from "./file-audit-log";
+import { SyslogAuditLog, type SyslogConfig } from "./syslog-audit-log";
+
+/**
+ * Audit log adapter types supported by the factory.
+ */
+export type AuditLogType = "memory" | "file" | "syslog";
+
+/**
+ * Configuration for creating audit log instances.
+ */
+export interface AuditLogFactoryConfig {
+  /** Type of audit log adapter. Default: "memory" */
+  type: AuditLogType;
+  /** File path for FileAuditLog (required when type is "file") */
+  filePath?: string;
+  /** Syslog configuration for SyslogAuditLog (optional when type is "syslog") */
+  syslogConfig?: Partial<SyslogConfig>;
+}
+
+/**
+ * Environment variable names for audit log configuration.
+ */
+export const AUDIT_LOG_ENV = {
+  TYPE: "HSM_AUDIT_LOG_TYPE",
+  FILE_PATH: "HSM_AUDIT_LOG_PATH",
+  SYSLOG_HOST: "HSM_SYSLOG_HOST",
+  SYSLOG_PORT: "HSM_SYSLOG_PORT",
+  SYSLOG_FACILITY: "HSM_SYSLOG_FACILITY",
+  SYSLOG_APP_NAME: "HSM_SYSLOG_APP_NAME",
+} as const;
+
+/**
+ * Factory for creating audit log instances based on configuration.
+ *
+ * Supports three adapter types:
+ * - "memory": In-memory (default, for development/testing)
+ * - "file": Append-only file with cryptographic chaining
+ * - "syslog": RFC 5424 syslog for enterprise SIEM integration
+ *
+ * Configuration can be provided via:
+ * - Direct config object
+ * - Environment variables (for production)
+ */
+export class AuditLogFactory {
+  /**
+   * Create an audit log instance from explicit configuration.
+   */
+  static create(config: AuditLogFactoryConfig): AuditLog {
+    switch (config.type) {
+      case "memory":
+        return new InMemoryAuditLog();
+
+      case "file":
+        if (!config.filePath) {
+          throw new Error(
+            "AuditLogFactory: filePath is required when type is 'file'",
+          );
+        }
+        return new FileAuditLog(config.filePath);
+
+      case "syslog":
+        return new SyslogAuditLog(config.syslogConfig);
+
+      default:
+        throw new Error(
+          `AuditLogFactory: unknown audit log type '${config.type as string}'`,
+        );
+    }
+  }
+
+  /**
+   * Create an audit log instance from environment variables.
+   *
+   * Environment variables:
+   * - HSM_AUDIT_LOG_TYPE: "memory" | "file" | "syslog" (default: "memory")
+   * - HSM_AUDIT_LOG_PATH: file path for FileAuditLog
+   * - HSM_SYSLOG_HOST: syslog server hostname
+   * - HSM_SYSLOG_PORT: syslog server port
+   * - HSM_SYSLOG_FACILITY: syslog facility name
+   * - HSM_SYSLOG_APP_NAME: application name for syslog
+   */
+  static createFromEnv(env: NodeJS.ProcessEnv = process.env): AuditLog {
+    const type = (env[AUDIT_LOG_ENV.TYPE] as AuditLogType) || "memory";
+
+    const config: AuditLogFactoryConfig = { type };
+
+    if (type === "file") {
+      const filePath = env[AUDIT_LOG_ENV.FILE_PATH];
+      if (filePath) {
+        config.filePath = filePath;
+      }
+    }
+
+    if (type === "syslog") {
+      const syslogConfig: Partial<SyslogConfig> = {};
+      const host = env[AUDIT_LOG_ENV.SYSLOG_HOST];
+      if (host) {
+        syslogConfig.host = host;
+      }
+      const port = env[AUDIT_LOG_ENV.SYSLOG_PORT];
+      if (port) {
+        syslogConfig.port = parseInt(port, 10);
+      }
+      const facility = env[AUDIT_LOG_ENV.SYSLOG_FACILITY];
+      if (facility) {
+        syslogConfig.facility = facility as SyslogConfig["facility"];
+      }
+      const appName = env[AUDIT_LOG_ENV.SYSLOG_APP_NAME];
+      if (appName) {
+        syslogConfig.appName = appName;
+      }
+      config.syslogConfig = syslogConfig;
+    }
+
+    return this.create(config);
+  }
+}

--- a/modules/hsm/src/infrastructure/file-audit-log.ts
+++ b/modules/hsm/src/infrastructure/file-audit-log.ts
@@ -1,0 +1,182 @@
+import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+
+import type { HsmAuditEntry } from "../domain/entities";
+import type { AuditLog } from "../domain/ports";
+
+/**
+ * Chained audit entry with cryptographic integrity.
+ * Each entry includes a hash of the previous entry, creating a tamper-evident chain.
+ */
+export interface ChainedAuditEntry extends HsmAuditEntry {
+  /** SHA-256 hash of the previous entry (hex). First entry uses "genesis". */
+  previousHash: string;
+  /** SHA-256 hash of this entry including previousHash (hex). */
+  entryHash: string;
+  /** Monotonic sequence number starting at 1. */
+  sequenceNumber: number;
+}
+
+/**
+ * Persistent audit log with append-only writes and cryptographic chaining.
+ *
+ * Each entry includes:
+ * - SHA-256 hash of the previous entry (tamper-evidence)
+ * - Monotonic sequence number (gap detection)
+ * - Entry hash for integrity verification
+ *
+ * File format: NDJSON (newline-delimited JSON) for append-only writes.
+ *
+ * Ref: NIST SP 800-57 Part 1, §8.1 — key management lifecycle auditing
+ */
+export class FileAuditLog implements AuditLog {
+  private readonly filePath: string;
+  private lastHash: string = "genesis";
+  private sequenceNumber: number = 0;
+  private readonly cache: ChainedAuditEntry[] = [];
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+    this.loadExistingEntries();
+  }
+
+  record(
+    operation: string,
+    keyLabel: string,
+    result: "success" | "failed",
+    detail?: string,
+  ): void {
+    this.sequenceNumber++;
+
+    const baseEntry: HsmAuditEntry = {
+      timestamp: new Date().toISOString(),
+      operation,
+      keyLabel,
+      result,
+    };
+    if (detail !== undefined) {
+      baseEntry.detail = detail;
+    }
+
+    const chainedEntry: ChainedAuditEntry = {
+      ...baseEntry,
+      previousHash: this.lastHash,
+      sequenceNumber: this.sequenceNumber,
+      entryHash: "", // Computed below
+    };
+
+    chainedEntry.entryHash = this.computeHash(chainedEntry);
+    this.lastHash = chainedEntry.entryHash;
+
+    this.appendToFile(chainedEntry);
+    this.cache.push(chainedEntry);
+  }
+
+  entries(): readonly HsmAuditEntry[] {
+    return this.cache.map((e) => {
+      const entry: HsmAuditEntry = {
+        timestamp: e.timestamp,
+        operation: e.operation,
+        keyLabel: e.keyLabel,
+        result: e.result,
+      };
+      if (e.detail !== undefined) {
+        entry.detail = e.detail;
+      }
+      return entry;
+    });
+  }
+
+  /**
+   * Get all chained entries including integrity metadata.
+   */
+  chainedEntries(): readonly ChainedAuditEntry[] {
+    return [...this.cache];
+  }
+
+  /**
+   * Verify the integrity of the entire audit chain.
+   * Returns true if all hashes are valid and sequence is unbroken.
+   */
+  verifyIntegrity(): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+    let expectedPreviousHash = "genesis";
+
+    for (let i = 0; i < this.cache.length; i++) {
+      const entry = this.cache[i]!;
+
+      // Verify sequence number
+      if (entry.sequenceNumber !== i + 1) {
+        errors.push(
+          `Entry ${i}: sequence number mismatch (expected ${i + 1}, got ${entry.sequenceNumber})`,
+        );
+      }
+
+      // Verify previous hash chain
+      if (entry.previousHash !== expectedPreviousHash) {
+        errors.push(
+          `Entry ${i}: previous hash mismatch (expected ${expectedPreviousHash.slice(0, 16)}..., got ${entry.previousHash.slice(0, 16)}...)`,
+        );
+      }
+
+      // Verify entry hash
+      const computedHash = this.computeHash(entry);
+      if (entry.entryHash !== computedHash) {
+        errors.push(
+          `Entry ${i}: entry hash mismatch (computed ${computedHash.slice(0, 16)}..., stored ${entry.entryHash.slice(0, 16)}...)`,
+        );
+      }
+
+      expectedPreviousHash = entry.entryHash;
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  /**
+   * Get the current chain tip hash for external anchoring.
+   */
+  getChainTipHash(): string {
+    return this.lastHash;
+  }
+
+  private computeHash(entry: ChainedAuditEntry): string {
+    const payload = JSON.stringify({
+      timestamp: entry.timestamp,
+      operation: entry.operation,
+      keyLabel: entry.keyLabel,
+      result: entry.result,
+      detail: entry.detail,
+      previousHash: entry.previousHash,
+      sequenceNumber: entry.sequenceNumber,
+    });
+    return createHash("sha256").update(payload).digest("hex");
+  }
+
+  private appendToFile(entry: ChainedAuditEntry): void {
+    const line = JSON.stringify(entry) + "\n";
+    appendFileSync(this.filePath, line, "utf-8");
+  }
+
+  private loadExistingEntries(): void {
+    if (!existsSync(this.filePath)) {
+      writeFileSync(this.filePath, "", "utf-8");
+      return;
+    }
+
+    const content = readFileSync(this.filePath, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+
+    for (const line of lines) {
+      const entry = JSON.parse(line) as ChainedAuditEntry;
+      this.cache.push(entry);
+      this.lastHash = entry.entryHash;
+      this.sequenceNumber = entry.sequenceNumber;
+    }
+  }
+}

--- a/modules/hsm/src/infrastructure/syslog-audit-log.ts
+++ b/modules/hsm/src/infrastructure/syslog-audit-log.ts
@@ -1,0 +1,232 @@
+import { createHash } from "node:crypto";
+import * as dgram from "node:dgram";
+
+import type { HsmAuditEntry } from "../domain/entities";
+import type { AuditLog } from "../domain/ports";
+
+/**
+ * Syslog severity levels per RFC 5424.
+ */
+export type SyslogSeverity =
+  | "emergency"
+  | "alert"
+  | "critical"
+  | "error"
+  | "warning"
+  | "notice"
+  | "info"
+  | "debug";
+
+/**
+ * Syslog facility codes per RFC 5424.
+ */
+export type SyslogFacility =
+  | "kern"
+  | "user"
+  | "mail"
+  | "daemon"
+  | "auth"
+  | "syslog"
+  | "lpr"
+  | "news"
+  | "uucp"
+  | "cron"
+  | "authpriv"
+  | "ftp"
+  | "local0"
+  | "local1"
+  | "local2"
+  | "local3"
+  | "local4"
+  | "local5"
+  | "local6"
+  | "local7";
+
+const FACILITY_CODES: Record<SyslogFacility, number> = {
+  kern: 0,
+  user: 1,
+  mail: 2,
+  daemon: 3,
+  auth: 4,
+  syslog: 5,
+  lpr: 6,
+  news: 7,
+  uucp: 8,
+  cron: 9,
+  authpriv: 10,
+  ftp: 11,
+  local0: 16,
+  local1: 17,
+  local2: 18,
+  local3: 19,
+  local4: 20,
+  local5: 21,
+  local6: 22,
+  local7: 23,
+};
+
+const SEVERITY_CODES: Record<SyslogSeverity, number> = {
+  emergency: 0,
+  alert: 1,
+  critical: 2,
+  error: 3,
+  warning: 4,
+  notice: 5,
+  info: 6,
+  debug: 7,
+};
+
+export interface SyslogConfig {
+  /** Syslog server hostname or IP address. Default: "127.0.0.1" */
+  host: string;
+  /** Syslog server port. Default: 514 */
+  port: number;
+  /** Syslog facility. Default: "auth" (security/authorization) */
+  facility: SyslogFacility;
+  /** Application name for syslog messages. Default: "hsm-audit" */
+  appName: string;
+  /** Protocol: UDP or TCP. Default: "udp" */
+  protocol: "udp" | "tcp";
+}
+
+export const DEFAULT_SYSLOG_CONFIG: SyslogConfig = {
+  host: "127.0.0.1",
+  port: 514,
+  facility: "auth",
+  appName: "hsm-audit",
+  protocol: "udp",
+};
+
+/**
+ * Syslog audit log adapter for enterprise SIEM integration.
+ *
+ * Sends HSM audit entries to a syslog server using RFC 5424 format.
+ * Also maintains an in-memory cache for the entries() API contract.
+ *
+ * Severity mapping:
+ * - "success" → info
+ * - "failed" → warning
+ *
+ * Ref: RFC 5424 — The Syslog Protocol
+ * Ref: NIST SP 800-57 Part 1, §8.1 — key management lifecycle auditing
+ */
+export class SyslogAuditLog implements AuditLog {
+  private readonly config: SyslogConfig;
+  private readonly cache: HsmAuditEntry[] = [];
+  private socket: dgram.Socket | null = null;
+  private sequenceNumber = 0;
+
+  constructor(config: Partial<SyslogConfig> = {}) {
+    this.config = { ...DEFAULT_SYSLOG_CONFIG, ...config };
+  }
+
+  record(
+    operation: string,
+    keyLabel: string,
+    result: "success" | "failed",
+    detail?: string,
+  ): void {
+    this.sequenceNumber++;
+
+    const entry: HsmAuditEntry = {
+      timestamp: new Date().toISOString(),
+      operation,
+      keyLabel,
+      result,
+    };
+    if (detail !== undefined) {
+      entry.detail = detail;
+    }
+
+    this.cache.push(entry);
+    this.sendToSyslog(entry);
+  }
+
+  entries(): readonly HsmAuditEntry[] {
+    return [...this.cache];
+  }
+
+  /**
+   * Close the UDP socket if open.
+   */
+  close(): void {
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  private sendToSyslog(entry: HsmAuditEntry): void {
+    const severity: SyslogSeverity =
+      entry.result === "success" ? "info" : "warning";
+    const message = this.formatSyslogMessage(entry, severity);
+
+    if (this.config.protocol === "udp") {
+      this.sendUdp(message);
+    }
+    // TCP support can be added later if needed
+  }
+
+  private formatSyslogMessage(
+    entry: HsmAuditEntry,
+    severity: SyslogSeverity,
+  ): string {
+    const priority =
+      FACILITY_CODES[this.config.facility] * 8 + SEVERITY_CODES[severity];
+    const timestamp = entry.timestamp;
+    const hostname = "-"; // NILVALUE per RFC 5424
+    const appName = this.config.appName;
+    const procId = process.pid.toString();
+    const msgId = `HSM_${entry.operation.toUpperCase()}`;
+
+    // Structured data with audit details
+    const entryHash = this.computeEntryHash(entry);
+    const structuredData =
+      `[hsm-audit@32473 operation="${entry.operation}" ` +
+      `keyLabel="${entry.keyLabel}" result="${entry.result}" ` +
+      `sequence="${this.sequenceNumber}" hash="${entryHash.slice(0, 16)}"]`;
+
+    // Human-readable message
+    const message = entry.detail
+      ? `${entry.operation} ${entry.keyLabel}: ${entry.result} - ${entry.detail}`
+      : `${entry.operation} ${entry.keyLabel}: ${entry.result}`;
+
+    // RFC 5424 format: <PRI>VERSION TIMESTAMP HOSTNAME APP-NAME PROCID MSGID SD MSG
+    return `<${priority}>1 ${timestamp} ${hostname} ${appName} ${procId} ${msgId} ${structuredData} ${message}`;
+  }
+
+  private computeEntryHash(entry: HsmAuditEntry): string {
+    const payload = JSON.stringify({
+      timestamp: entry.timestamp,
+      operation: entry.operation,
+      keyLabel: entry.keyLabel,
+      result: entry.result,
+      detail: entry.detail,
+      sequenceNumber: this.sequenceNumber,
+    });
+    return createHash("sha256").update(payload).digest("hex");
+  }
+
+  private sendUdp(message: string): void {
+    if (!this.socket) {
+      this.socket = dgram.createSocket("udp4");
+    }
+
+    const buffer = Buffer.from(message, "utf-8");
+    this.socket.send(
+      buffer,
+      0,
+      buffer.length,
+      this.config.port,
+      this.config.host,
+      (err) => {
+        if (err) {
+          // Log to stderr but don't throw — audit logging shouldn't break HSM operations
+          console.error(
+            `SyslogAuditLog: failed to send to ${this.config.host}:${this.config.port}: ${err.message}`,
+          );
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add `FileAuditLog` with NDJSON format and cryptographic chaining (SHA-256 hash of previous entry, sequence numbers, `verifyIntegrity()` method)
- Add `SyslogAuditLog` for enterprise SIEM integration using RFC 5424 format over UDP
- Add `AuditLogFactory` for environment-based adapter selection (`HSM_AUDIT_LOG_TYPE`, `HSM_AUDIT_LOG_PATH`, `HSM_SYSLOG_*`)
- Update docs with usage examples and configuration reference

## Test plan

- [x] All 179 existing tests pass
- [x] TypeScript strict mode (`exactOptionalPropertyTypes`) satisfied
- [x] ESLint and Prettier checks pass

Closes #63