### PR TITLE
feat(telemetry): add OpenTelemetry distributed tracing and metrics

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,250 @@
+# Observability
+
+How to instrument and monitor the enterprise blockchain integration layer using OpenTelemetry.
+
+## Overview
+
+The repository provides OpenTelemetry instrumentation for:
+
+- **Distributed tracing**: Track requests across blockchain protocol boundaries
+- **Metrics**: Monitor retry counts, circuit breaker states, and operation latencies
+- **Structured logging**: Correlate logs with trace context
+
+## Quick Start
+
+### 1. Enable telemetry export
+
+Set the OTLP endpoint environment variable:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+export OTEL_SERVICE_NAME=my-blockchain-service
+```
+
+### 2. Initialize the SDK (optional)
+
+For automatic instrumentation, import the SDK initialization at application startup:
+
+```typescript
+// Import BEFORE any other imports
+import "@enterprise-blockchain/shared/telemetry-sdk";
+
+// Then import your application code
+import { FabricGateway } from "./fabric-gateway";
+```
+
+### 3. Create tracers and meters
+
+```typescript
+import { createTracer, createMeter } from "@enterprise-blockchain/shared";
+
+const tracer = createTracer("my-service");
+const meter = createMeter("my-service");
+```
+
+## Instrumented Components
+
+### Retry Policy (`withRetry`)
+
+The `withRetry` function creates spans for each retry attempt:
+
+```
+retry.operation (parent span)
+├── retry.attempt (attempt 1)
+├── retry.attempt (attempt 2, with backoff event)
+└── retry.attempt (attempt 3)
+```
+
+**Span attributes:**
+
+| Attribute              | Description                         |
+| ---------------------- | ----------------------------------- |
+| `retry.attempt`        | Current attempt number (1-indexed)  |
+| `retry.max_attempts`   | Maximum attempts configured         |
+| `retry.error_code`     | Error code from failed attempt      |
+| `retry.delay_ms`       | Backoff delay before next attempt   |
+| `retry.total_attempts` | Total attempts made (on completion) |
+
+**Metrics:**
+
+| Metric            | Type    | Description                              |
+| ----------------- | ------- | ---------------------------------------- |
+| `retry.attempts`  | Counter | Number of retry attempts                 |
+| `retry.successes` | Counter | Successful operations (with retry count) |
+| `retry.failures`  | Counter | Operations that failed after all retries |
+
+### Circuit Breaker
+
+The `CircuitBreaker` class emits state transition metrics:
+
+**Metrics:**
+
+| Metric                        | Type    | Description                                   |
+| ----------------------------- | ------- | --------------------------------------------- |
+| `circuit_breaker.state`       | Gauge   | Current state (0=closed, 1=half-open, 2=open) |
+| `circuit_breaker.transitions` | Counter | State transitions with from/to labels         |
+
+**Labels:**
+
+| Label                        | Description                    |
+| ---------------------------- | ------------------------------ |
+| `circuit_breaker.name`       | Circuit breaker instance name  |
+| `circuit_breaker.from_state` | Previous state (on transition) |
+| `circuit_breaker.to_state`   | New state (on transition)      |
+
+## Environment Variables
+
+| Variable                      | Default                 | Description                         |
+| ----------------------------- | ----------------------- | ----------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none)                  | OTLP collector URL (enables export) |
+| `OTEL_SERVICE_NAME`           | `enterprise-blockchain` | Service name in traces              |
+| `OTEL_TRACES_EXPORTER`        | `otlp`                  | Trace exporter type                 |
+| `OTEL_METRICS_EXPORTER`       | `otlp`                  | Metrics exporter type               |
+
+When `OTEL_EXPORTER_OTLP_ENDPOINT` is not set, telemetry is disabled (no-op mode).
+
+## Collector Setup
+
+### Local development with Jaeger
+
+```bash
+docker run -d --name jaeger \
+  -p 16686:16686 \
+  -p 4318:4318 \
+  jaegertracing/all-in-one:latest
+```
+
+Access the Jaeger UI at http://localhost:16686
+
+### Production with OpenTelemetry Collector
+
+Deploy the OpenTelemetry Collector with OTLP receivers:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  jaeger:
+    endpoint: jaeger:14250
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:9090
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+```
+
+## Custom Instrumentation
+
+### Creating spans
+
+```typescript
+import {
+  createTracer,
+  withSpan,
+  TelemetryAttributes,
+} from "@enterprise-blockchain/shared";
+
+const tracer = createTracer("my-service");
+
+async function submitTransaction(txId: string): Promise<void> {
+  await withSpan(tracer, "submit.transaction", async (span) => {
+    span.setAttribute(TelemetryAttributes.BLOCKCHAIN_TX_ID, txId);
+    span.setAttribute(TelemetryAttributes.BLOCKCHAIN_PLATFORM, "fabric");
+
+    // ... transaction logic
+
+    span.addEvent("endorsement.complete", {
+      endorsers: 3,
+    });
+  });
+}
+```
+
+### Creating metrics
+
+```typescript
+import { createMeter } from "@enterprise-blockchain/shared";
+
+const meter = createMeter("my-service");
+
+const txCounter = meter.createCounter("transactions.submitted", {
+  description: "Number of transactions submitted",
+  unit: "1",
+});
+
+const txLatency = meter.createHistogram("transactions.latency", {
+  description: "Transaction latency",
+  unit: "ms",
+});
+
+// Record metrics
+txCounter.add(1, { platform: "fabric", channel: "mychannel" });
+txLatency.record(150, { platform: "fabric" });
+```
+
+## Trace Context Propagation
+
+When calling external services, propagate trace context:
+
+```typescript
+import { context, propagation } from "@enterprise-blockchain/shared";
+
+// Inject context into headers
+const headers: Record<string, string> = {};
+propagation.inject(context.active(), headers);
+
+// Send request with propagated context
+await fetch(url, { headers });
+```
+
+## Semantic Conventions
+
+Use the provided `TelemetryAttributes` for consistency:
+
+```typescript
+import { TelemetryAttributes } from "@enterprise-blockchain/shared";
+
+span.setAttribute(TelemetryAttributes.BLOCKCHAIN_PLATFORM, "besu");
+span.setAttribute(TelemetryAttributes.BLOCKCHAIN_TX_ID, txHash);
+span.setAttribute(TelemetryAttributes.RETRY_ATTEMPT, 2);
+span.setAttribute(TelemetryAttributes.CIRCUIT_BREAKER_STATE, "open");
+```
+
+## Grafana Dashboards
+
+Example PromQL queries for Grafana:
+
+```promql
+# Retry success rate
+sum(rate(retry_successes_total[5m])) / sum(rate(retry_attempts_total[5m]))
+
+# Circuit breaker open rate
+sum(circuit_breaker_state == 2) by (circuit_breaker_name)
+
+# P95 transaction latency
+histogram_quantile(0.95, rate(transactions_latency_bucket[5m]))
+```
+
+## References
+
+- [OpenTelemetry JavaScript](https://opentelemetry.io/docs/languages/js/)
+- [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [OTLP Specification](https://opentelemetry.io/docs/specs/otlp/)

--- a/modules/integrations/shared/src/retry.ts
+++ b/modules/integrations/shared/src/retry.ts
@@ -5,7 +5,54 @@
  * - Fabric: UNAVAILABLE, DEADLINE_EXCEEDED gRPC status codes
  * - Besu: SERVER_ERROR, TIMEOUT JSON-RPC errors (not NONCE_TOO_LOW)
  * - Corda: HTTP 502/503/504 (not 400/401/403)
+ *
+ * OpenTelemetry instrumentation:
+ * - withRetry() creates spans per attempt with error code attributes
+ * - CircuitBreaker emits state transition metrics
  */
+
+import {
+  createTracer,
+  createMeter,
+  TelemetryAttributes,
+  SpanStatusCode,
+} from "../../../shared/src/telemetry";
+
+const tracer = createTracer("retry-policy");
+const meter = createMeter("circuit-breaker");
+
+// Metrics
+const retryAttemptCounter = meter.createCounter("retry.attempts", {
+  description: "Number of retry attempts",
+  unit: "1",
+});
+
+const retrySuccessCounter = meter.createCounter("retry.successes", {
+  description: "Number of successful operations (with or without retries)",
+  unit: "1",
+});
+
+const retryFailureCounter = meter.createCounter("retry.failures", {
+  description: "Number of operations that failed after all retries",
+  unit: "1",
+});
+
+const circuitBreakerStateGauge = meter.createObservableGauge(
+  "circuit_breaker.state",
+  {
+    description:
+      "Current circuit breaker state (0=closed, 1=half-open, 2=open)",
+    unit: "1",
+  },
+);
+
+const circuitBreakerTransitions = meter.createCounter(
+  "circuit_breaker.transitions",
+  {
+    description: "Number of circuit breaker state transitions",
+    unit: "1",
+  },
+);
 
 export interface RetryPolicy {
   maxAttempts: number;
@@ -75,31 +122,105 @@ export async function withRetry<T>(
   policy: RetryPolicy,
   nonRetryable: string[] = [],
   extractErrorCode: (err: unknown) => string = defaultExtractErrorCode,
+  operationName = "operation",
 ): Promise<T> {
   if (policy.maxAttempts < 1) {
     throw new Error("RetryPolicy.maxAttempts must be >= 1");
   }
-  let lastError: unknown;
 
-  for (let attempt = 0; attempt < policy.maxAttempts; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err;
-      const code = extractErrorCode(err);
+  return tracer.startActiveSpan(
+    `retry.${operationName}`,
+    {
+      attributes: {
+        [TelemetryAttributes.RETRY_MAX_ATTEMPTS]: policy.maxAttempts,
+      },
+    },
+    async (parentSpan) => {
+      let lastError: unknown;
 
-      if (!isRetryable(code, policy, nonRetryable)) {
-        throw err;
+      for (let attempt = 0; attempt < policy.maxAttempts; attempt++) {
+        const attemptSpan = tracer.startSpan(`retry.attempt`, {
+          attributes: {
+            [TelemetryAttributes.RETRY_ATTEMPT]: attempt + 1,
+            [TelemetryAttributes.RETRY_MAX_ATTEMPTS]: policy.maxAttempts,
+          },
+        });
+
+        try {
+          retryAttemptCounter.add(1, {
+            [TelemetryAttributes.RETRY_ATTEMPT]: attempt + 1,
+          });
+
+          const result = await fn();
+
+          attemptSpan.setStatus({ code: SpanStatusCode.OK });
+          attemptSpan.end();
+          parentSpan.setStatus({ code: SpanStatusCode.OK });
+          parentSpan.setAttribute("retry.total_attempts", attempt + 1);
+          parentSpan.end();
+
+          retrySuccessCounter.add(1, {
+            "retry.total_attempts": attempt + 1,
+          });
+
+          return result;
+        } catch (err) {
+          lastError = err;
+          const code = extractErrorCode(err);
+
+          attemptSpan.setAttribute(TelemetryAttributes.RETRY_ERROR_CODE, code);
+          attemptSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: err instanceof Error ? err.message : String(err),
+          });
+          if (err instanceof Error) {
+            attemptSpan.recordException(err);
+          }
+          attemptSpan.end();
+
+          if (!isRetryable(code, policy, nonRetryable)) {
+            parentSpan.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: `Non-retryable error: ${code}`,
+            });
+            parentSpan.setAttribute("retry.total_attempts", attempt + 1);
+            parentSpan.setAttribute(TelemetryAttributes.RETRY_ERROR_CODE, code);
+            parentSpan.end();
+
+            retryFailureCounter.add(1, {
+              [TelemetryAttributes.RETRY_ERROR_CODE]: code,
+              "retry.retryable": false,
+            });
+
+            throw err;
+          }
+
+          if (attempt < policy.maxAttempts - 1) {
+            const delay = computeDelay(attempt, policy);
+            parentSpan.addEvent("retry.backoff", {
+              [TelemetryAttributes.RETRY_DELAY_MS]: delay,
+              [TelemetryAttributes.RETRY_ATTEMPT]: attempt + 1,
+            });
+            await sleep(delay);
+          }
+        }
       }
 
-      if (attempt < policy.maxAttempts - 1) {
-        const delay = computeDelay(attempt, policy);
-        await sleep(delay);
-      }
-    }
-  }
+      parentSpan.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `All ${policy.maxAttempts} attempts exhausted`,
+      });
+      parentSpan.setAttribute("retry.total_attempts", policy.maxAttempts);
+      parentSpan.end();
 
-  throw lastError;
+      retryFailureCounter.add(1, {
+        "retry.retryable": true,
+        "retry.exhausted": true,
+      });
+
+      throw lastError;
+    },
+  );
 }
 
 // ── Circuit Breaker ─────────────────────────────────────────────────
@@ -121,16 +242,27 @@ export class CircuitBreaker {
   private consecutiveFailures = 0;
   private lastFailureTime = 0;
   private readonly options: CircuitBreakerOptions;
+  private readonly name: string;
 
-  constructor(options: Partial<CircuitBreakerOptions> = {}) {
+  constructor(options: Partial<CircuitBreakerOptions> = {}, name = "default") {
     this.options = { ...DEFAULT_CIRCUIT_BREAKER_OPTIONS, ...options };
+    this.name = name;
+
+    // Register observable gauge for this circuit breaker
+    circuitBreakerStateGauge.addCallback((result) => {
+      const stateValue =
+        this.state === "closed" ? 0 : this.state === "half-open" ? 1 : 2;
+      result.observe(stateValue, {
+        "circuit_breaker.name": this.name,
+      });
+    });
   }
 
   getState(): CircuitState {
     if (this.state === "open") {
       const elapsed = Date.now() - this.lastFailureTime;
       if (elapsed >= this.options.cooldownMs) {
-        this.state = "half-open";
+        this.transitionTo("half-open");
       }
     }
     return this.state;
@@ -149,7 +281,7 @@ export class CircuitBreaker {
     // Immediately transition to open so concurrent callers are blocked
     // (prevents thundering herd after cooldown).
     if (currentState === "half-open") {
-      this.state = "open";
+      this.transitionTo("open");
     }
 
     try {
@@ -162,9 +294,22 @@ export class CircuitBreaker {
     }
   }
 
+  private transitionTo(newState: CircuitState): void {
+    if (this.state !== newState) {
+      const previousState = this.state;
+      this.state = newState;
+
+      circuitBreakerTransitions.add(1, {
+        "circuit_breaker.name": this.name,
+        "circuit_breaker.from_state": previousState,
+        "circuit_breaker.to_state": newState,
+      });
+    }
+  }
+
   private onSuccess(): void {
     this.consecutiveFailures = 0;
-    this.state = "closed";
+    this.transitionTo("closed");
   }
 
   private onFailure(): void {
@@ -172,13 +317,13 @@ export class CircuitBreaker {
     this.lastFailureTime = Date.now();
 
     if (this.consecutiveFailures >= this.options.failureThreshold) {
-      this.state = "open";
+      this.transitionTo("open");
     }
   }
 
   /** Reset the circuit to closed state. Useful for testing. */
   reset(): void {
-    this.state = "closed";
+    this.transitionTo("closed");
     this.consecutiveFailures = 0;
     this.lastFailureTime = 0;
   }

--- a/modules/shared/src/index.ts
+++ b/modules/shared/src/index.ts
@@ -6,3 +6,18 @@ export { InMemoryStore } from "./store";
 export { CollectionStore } from "./collection-store";
 export type { Logger, LogFields } from "./logger";
 export { ConsoleLogger, noopLogger } from "./logger";
+
+// Telemetry
+export type { Tracer, Meter, Span, SpanOptions, Context } from "./telemetry";
+export {
+  createTracer,
+  createMeter,
+  withSpan,
+  withSpanSync,
+  isTelemetryEnabled,
+  TelemetryAttributes,
+  SpanStatusCode,
+  context,
+  propagation,
+  SERVICE_NAME,
+} from "./telemetry";

--- a/modules/shared/src/telemetry-sdk.ts
+++ b/modules/shared/src/telemetry-sdk.ts
@@ -1,0 +1,82 @@
+/**
+ * OpenTelemetry SDK initialization.
+ *
+ * This module should be imported at application startup BEFORE any other
+ * imports to ensure proper instrumentation:
+ *
+ *   import "@enterprise-blockchain/shared/telemetry-sdk";
+ *
+ * The SDK is configured via standard OpenTelemetry environment variables:
+ * - OTEL_SERVICE_NAME: Service name (default: "enterprise-blockchain")
+ * - OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (e.g., "http://localhost:4318")
+ * - OTEL_TRACES_EXPORTER: Trace exporter type (default: "otlp" if endpoint set)
+ * - OTEL_METRICS_EXPORTER: Metrics exporter type (default: "otlp" if endpoint set)
+ *
+ * If OTEL_EXPORTER_OTLP_ENDPOINT is not set, telemetry is disabled (no-op).
+ *
+ * Ref: https://opentelemetry.io/docs/languages/js/getting-started/nodejs/
+ */
+
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+const serviceName = process.env.OTEL_SERVICE_NAME ?? "enterprise-blockchain";
+
+let sdk: NodeSDK | null = null;
+
+if (endpoint) {
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${endpoint}/v1/traces`,
+  });
+
+  const metricExporter = new OTLPMetricExporter({
+    url: `${endpoint}/v1/metrics`,
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 10_000, // Export metrics every 10 seconds
+  });
+
+  sdk = new NodeSDK({
+    resource,
+    traceExporter,
+    metricReader,
+  });
+
+  sdk.start();
+
+  // Graceful shutdown handler
+  const shutdown = (): void => {
+    sdk
+      ?.shutdown()
+      .then(() => {
+        console.log("OpenTelemetry SDK shut down successfully");
+      })
+      .catch((err: unknown) => {
+        console.error("Error shutting down OpenTelemetry SDK:", err);
+      });
+  };
+
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
+
+  console.log(
+    `OpenTelemetry SDK initialized: service=${serviceName}, endpoint=${endpoint}`,
+  );
+} else {
+  console.log(
+    "OpenTelemetry SDK not initialized: OTEL_EXPORTER_OTLP_ENDPOINT not set",
+  );
+}
+
+export { sdk };

--- a/modules/shared/src/telemetry.ts
+++ b/modules/shared/src/telemetry.ts
@@ -1,0 +1,163 @@
+/**
+ * OpenTelemetry instrumentation for distributed tracing and metrics.
+ *
+ * Provides tracer and meter factories that integrate with the OpenTelemetry
+ * SDK. When OTEL_EXPORTER_OTLP_ENDPOINT is set, telemetry is exported to
+ * the configured collector; otherwise, telemetry is a no-op.
+ *
+ * Usage:
+ *   import { createTracer, createMeter } from "@enterprise-blockchain/shared";
+ *   const tracer = createTracer("my-service");
+ *   const meter = createMeter("my-service");
+ *
+ * Ref: OpenTelemetry Specification — https://opentelemetry.io/docs/specs/otel/
+ */
+
+import {
+  trace,
+  metrics,
+  context,
+  propagation,
+  SpanStatusCode,
+  type Tracer,
+  type Meter,
+  type Span,
+  type SpanOptions,
+  type Context,
+} from "@opentelemetry/api";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+// Re-export types for consumers
+export type { Tracer, Meter, Span, SpanOptions, Context };
+export { SpanStatusCode, context, propagation };
+
+/**
+ * Service name for telemetry, read from OTEL_SERVICE_NAME or defaulting
+ * to "enterprise-blockchain".
+ */
+export const SERVICE_NAME =
+  process.env.OTEL_SERVICE_NAME ?? "enterprise-blockchain";
+
+/**
+ * Whether telemetry export is enabled (OTEL_EXPORTER_OTLP_ENDPOINT is set).
+ */
+export function isTelemetryEnabled(): boolean {
+  return Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT);
+}
+
+/**
+ * Create a tracer for distributed tracing.
+ *
+ * @param name - The name of the instrumentation scope (e.g., "fabric-gateway")
+ * @param version - Optional version string for the instrumentation
+ */
+export function createTracer(name: string, version?: string): Tracer {
+  return trace.getTracer(name, version);
+}
+
+/**
+ * Create a meter for metrics collection.
+ *
+ * @param name - The name of the instrumentation scope (e.g., "circuit-breaker")
+ * @param version - Optional version string for the instrumentation
+ */
+export function createMeter(name: string, version?: string): Meter {
+  return metrics.getMeter(name, version);
+}
+
+/**
+ * Attribute keys for telemetry following OpenTelemetry semantic conventions.
+ */
+export const TelemetryAttributes = {
+  // Service attributes
+  SERVICE_NAME: ATTR_SERVICE_NAME,
+
+  // Retry attributes
+  RETRY_ATTEMPT: "retry.attempt",
+  RETRY_MAX_ATTEMPTS: "retry.max_attempts",
+  RETRY_ERROR_CODE: "retry.error_code",
+  RETRY_DELAY_MS: "retry.delay_ms",
+
+  // Circuit breaker attributes
+  CIRCUIT_BREAKER_STATE: "circuit_breaker.state",
+  CIRCUIT_BREAKER_FAILURES: "circuit_breaker.consecutive_failures",
+  CIRCUIT_BREAKER_COOLDOWN_MS: "circuit_breaker.cooldown_ms",
+
+  // Blockchain attributes
+  BLOCKCHAIN_PLATFORM: "blockchain.platform",
+  BLOCKCHAIN_CHANNEL: "blockchain.channel",
+  BLOCKCHAIN_CHAINCODE: "blockchain.chaincode",
+  BLOCKCHAIN_TX_ID: "blockchain.transaction_id",
+  BLOCKCHAIN_BLOCK_NUMBER: "blockchain.block_number",
+
+  // Error attributes
+  ERROR_TYPE: "error.type",
+  ERROR_MESSAGE: "error.message",
+} as const;
+
+/**
+ * Helper to run a function within a new span.
+ *
+ * @param tracer - The tracer to use
+ * @param name - Span name
+ * @param fn - Function to execute within the span
+ * @param options - Optional span options
+ */
+export async function withSpan<T>(
+  tracer: Tracer,
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  options?: SpanOptions,
+): Promise<T> {
+  return tracer.startActiveSpan(name, options ?? {}, async (span) => {
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      if (err instanceof Error) {
+        span.recordException(err);
+      }
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Helper to run a synchronous function within a new span.
+ *
+ * @param tracer - The tracer to use
+ * @param name - Span name
+ * @param fn - Function to execute within the span
+ * @param options - Optional span options
+ */
+export function withSpanSync<T>(
+  tracer: Tracer,
+  name: string,
+  fn: (span: Span) => T,
+  options?: SpanOptions,
+): T {
+  const span = tracer.startSpan(name, options);
+  try {
+    const result = fn(span);
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (err) {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    if (err instanceof Error) {
+      span.recordException(err);
+    }
+    throw err;
+  } finally {
+    span.end();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,11 @@
         "@grpc/grpc-js": "^1.14.3",
         "@hyperledger/fabric-gateway": "^1.10.1",
         "@noble/post-quantum": "^0.5.4",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+        "@opentelemetry/sdk-node": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ethers": "^6.16.0"
       },
       "devDependencies": {
@@ -34,7 +39,7 @@
         "typescript-eslint": "^8.57.0"
       },
       "engines": {
-        "node": ">=22.13.0"
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1183,6 +1188,7 @@
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1200,7 +1206,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
@@ -1208,6 +1215,7 @@
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1226,6 +1234,7 @@
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -1244,6 +1253,7 @@
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1337,6 +1347,7 @@
       "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "http-proxy-agent": "^7.0.0",
@@ -1354,6 +1365,7 @@
       "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1568,6 +1580,520 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.214.0.tgz",
+      "integrity": "sha512-Q+awuEwxhETwIAXuxHvIY5ZMEP0ZqvxLTi9kclrkyVJppEUXYL3Bhiw3jYrxdHYMh0Y0tVInQH9FEZ1aMinvLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "yaml": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-SwmFRwO8mi6nndzbsjPgSFg7qy1WeNHRFD+s6uCsdiUDUt3+yzI2qiHE3/ub2f37+/CbeGcG+Ugc8Gwr6nu2Aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/sdk-logs": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-9qv2Tl/Hq6qc5pJCbzFJnzA0uvlb9DgM70yGJPYf3bA5LlLkRCpcn81i4JbcIH4grlQIWY6A+W7YG0LLvS1BAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/sdk-logs": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-IWAVvCO1TlpotRjFmhQFz9RSfQy5BsLtDRBtptSrXZRwfyRPpuql/RMe5zdmu0Gxl3ERDFwOzOqkf3bwy7Jzcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-0NGxWHVYHgbp51SEzmsP+Hdups81eRs229STcSWHo3WO0aqY6RpJ9csxfyEtFgaNrBDv6UfOh0je4ss/ROS6XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-Tx/59RmjBgkXJ3qnsD04rpDrVWL53LU/czpgLJh+Ab98nAroe91I7vZ3uGN9mxwPS0jsZEnmqmHygVwB2vRMlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-pJIcghFGhx3VSCgP5U+yZx+OMNj0t+ttnhC8IjL5Wza7vWIczctF6t3AGcVQffi2dEqX+ZHANoBwoPR8y6RMKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.214.0.tgz",
+      "integrity": "sha512-4TGYoZKebUWVuYkV6r5wS2dUF4zH7EbWFw/Uqz1ZM1tGHQeFT9wzHGXq3iSIXMUrwu5jRdxjfMaXrYejPu2kpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.214.0.tgz",
+      "integrity": "sha512-FWRZ7AWoTryYhthralHkfXUuyO3l7cRsnr49WcDio1orl2a7KxT8aDZdwQtV1adzoUvZ9Gfo+IstElghCS4zfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.214.0.tgz",
+      "integrity": "sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.214.0.tgz",
+      "integrity": "sha512-ON0spYWb2yAdQ9b+ItNyK0c6qdtcs+0eVR4YFJkhJL7agfT8sHFg0e5EesauSRiTHPZHiDobI92k77q0lwAmqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.6.1.tgz",
+      "integrity": "sha512-km2/hD3inLTqtLnUAHDGz7ZP/VOyZNslrC/iN66x4jkmpckwlONW54LRPNI6fm09/musDtZga9EWsxgwnjGUlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.214.0.tgz",
+      "integrity": "sha512-IDP6zcyA24RhNZ289MP6eToIZcinlmirHjX8v3zKCQ2ZhPpt5cGwkN91tCth337lqHIgWcTy90uKRiX/SzALDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/otlp-transformer": "0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.214.0.tgz",
+      "integrity": "sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.6.1.tgz",
+      "integrity": "sha512-Dvz9TA6cPqIbxolSzQ5x9br6iQlqdGhVYrm+oYc7pfJ7LaVXz8F0XIqhWbnKB5YvfZ6SUmabBUUxnvHs/9uhxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.6.1.tgz",
+      "integrity": "sha512-kKFMxBcjBZAC1vBch5mtZ/dJQvcAEKWga+c+q5iGgRLPIE6Mc649zEwMaCIQCzalziMJQiyUadFYMHmELB7AFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.214.0.tgz",
+      "integrity": "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.1.tgz",
+      "integrity": "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.214.0.tgz",
+      "integrity": "sha512-gl2XvQBJuPjhGcw9SsnQO5qxChAPMuGRPFaD8lqtF+Cey91NgGUQ0sio2vlDFOSm3JOLzc44vL+OAfx1dXuZjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/configuration": "0.214.0",
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-prometheus": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.214.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.214.0",
+        "@opentelemetry/exporter-zipkin": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/otlp-exporter-base": "0.214.0",
+        "@opentelemetry/propagator-b3": "2.6.1",
+        "@opentelemetry/propagator-jaeger": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/sdk-logs": "0.214.0",
+        "@opentelemetry/sdk-metrics": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1",
+        "@opentelemetry/sdk-trace-node": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2584,6 +3110,7 @@
       "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -2592,13 +3119,21 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2908,6 +3443,7 @@
       "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
@@ -2965,9 +3501,16 @@
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -3578,7 +4121,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3686,7 +4228,8 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3909,7 +4452,8 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -4291,7 +4835,8 @@
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
       "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4521,6 +5066,7 @@
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4538,6 +5084,7 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=14"
       },
@@ -4585,6 +5132,7 @@
       "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -4715,6 +5263,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -4748,7 +5297,8 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -4756,6 +5306,7 @@
       "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -4766,6 +5317,7 @@
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -4901,7 +5453,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -5044,6 +5597,21 @@
         "node": ">=18.20"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
+      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -5128,6 +5696,7 @@
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 12"
       }
@@ -5274,6 +5843,7 @@
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -5693,6 +6263,7 @@
       "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "@npmcli/agent": "^3.0.0",
         "cacache": "^19.0.1",
@@ -5864,6 +6435,7 @@
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -5874,6 +6446,7 @@
       "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -5887,6 +6460,7 @@
       "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
@@ -5905,6 +6479,7 @@
       "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5918,6 +6493,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5930,7 +6506,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -5938,6 +6515,7 @@
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5951,6 +6529,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5963,7 +6542,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
@@ -5971,6 +6551,7 @@
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -5984,6 +6565,7 @@
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5996,7 +6578,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
@@ -6004,6 +6587,7 @@
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -6019,6 +6603,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/moo": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
@@ -6031,7 +6621,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6107,6 +6696,7 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6161,6 +6751,7 @@
       "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
@@ -6186,6 +6777,7 @@
       "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -6196,6 +6788,7 @@
       "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -6212,6 +6805,7 @@
       "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -8372,7 +8966,8 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/packageurl-js": {
       "version": "2.0.1",
@@ -8476,6 +9071,7 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -8696,6 +9292,7 @@
       "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -8713,6 +9310,7 @@
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -8954,6 +9552,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -9037,6 +9648,7 @@
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -9650,6 +10262,7 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -9675,6 +10288,7 @@
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -9690,6 +10304,7 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9779,6 +10394,7 @@
       "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.3"
       },
@@ -9841,6 +10457,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -9856,6 +10473,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9866,6 +10484,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9876,6 +10495,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9906,6 +10526,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -9919,6 +10540,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10020,6 +10642,7 @@
       "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -10434,6 +11057,7 @@
       "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "unique-slug": "^5.0.0"
       },
@@ -10447,6 +11071,7 @@
       "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
@@ -10601,6 +11226,7 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10619,6 +11245,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10629,6 +11256,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -10645,6 +11273,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10655,6 +11284,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10670,6 +11300,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10772,6 +11403,7 @@
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -10780,7 +11412,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,11 @@
     "@grpc/grpc-js": "^1.14.3",
     "@hyperledger/fabric-gateway": "^1.10.1",
     "@noble/post-quantum": "^0.5.4",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
+    "@opentelemetry/sdk-node": "^0.214.0",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
     "ethers": "^6.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add production-ready OpenTelemetry infrastructure for distributed tracing and metrics
- Instrument retry policy with per-attempt spans, error codes, and backoff events
- Instrument circuit breaker with state gauge and transition counter
- Add comprehensive observability documentation with collector setup examples

## Changes
- **modules/shared/src/telemetry.ts**: Core telemetry utilities (createTracer, createMeter, withSpan helpers, TelemetryAttributes)
- **modules/shared/src/telemetry-sdk.ts**: NodeSDK initialization with OTLP HTTP exporters
- **modules/integrations/shared/src/retry.ts**: Instrumented with spans and metrics
- **docs/architecture/observability.md**: Setup guide with environment variables and Jaeger/Prometheus examples

## Test plan
- [x] All existing tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes with zero warnings
- [x] Examples run successfully

Closes #56