### PR TITLE
feat(hsm): add real PKCS#11 hardware HSM support via graphene-pk11

### DIFF
--- a/examples/hsm-real-pkcs11/index.ts
+++ b/examples/hsm-real-pkcs11/index.ts
@@ -1,0 +1,343 @@
+/**
+ * HSM Real PKCS#11 Example
+ *
+ * Demonstrates the HsmClient with real PKCS#11 hardware HSM support.
+ * Falls back to simulator mode if SoftHSM2 is not available.
+ *
+ * Features demonstrated:
+ * - EC P-256, P-384 key generation and ECDSA signing
+ * - Ed25519 key generation and EdDSA signing
+ * - RSA-4096 key generation and RSA-PSS signing
+ * - AES-256 key generation and envelope encryption
+ *
+ * Prerequisites for PKCS#11 mode:
+ * 1. Install SoftHSM2: apt-get install softhsm2
+ * 2. Initialize a token: softhsm2-util --init-token --slot 0 --label "test" --so-pin 1234567890 --pin 1234
+ * 3. Set environment variables:
+ *    - HSM_LIBRARY_PATH=/usr/lib/softhsm/libsofthsm2.so
+ *    - HSM_PIN=1234
+ *
+ * Or use Docker:
+ *   cd infra/softhsm2 && docker compose up -d
+ *
+ * Run: tsx examples/hsm-real-pkcs11/index.ts
+ */
+
+import { existsSync } from "node:fs";
+import { HsmClient, type Pkcs11CryptoConfig } from "../../modules/hsm/src";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Common SoftHSM2 library paths by OS
+const SOFTHSM2_PATHS = [
+  "/usr/lib/softhsm/libsofthsm2.so", // Debian/Ubuntu
+  "/usr/local/lib/softhsm/libsofthsm2.so", // macOS (brew)
+  "/opt/homebrew/lib/softhsm/libsofthsm2.so", // macOS ARM (brew)
+  "/usr/lib64/pkcs11/libsofthsm2.so", // RHEL/CentOS
+  process.env.HSM_LIBRARY_PATH ?? "",
+].filter(Boolean);
+
+function findSoftHsm2Library(): string | undefined {
+  for (const path of SOFTHSM2_PATHS) {
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main Example
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log(
+    "╔══════════════════════════════════════════════════════════════╗",
+  );
+  console.log(
+    "║        HSM Real PKCS#11 Example                              ║",
+  );
+  console.log(
+    "║        EC P-256/P-384, Ed25519, RSA-4096, AES-256           ║",
+  );
+  console.log(
+    "╚══════════════════════════════════════════════════════════════╝\n",
+  );
+
+  const hsm = new HsmClient();
+  const softHsmPath = findSoftHsm2Library();
+  const userPin = process.env.HSM_PIN ?? "1234";
+
+  if (softHsmPath) {
+    console.log(`[INFO] Found SoftHSM2 at: ${softHsmPath}`);
+    console.log("[INFO] Initializing in PKCS#11 mode...\n");
+
+    const pkcs11Config: Pkcs11CryptoConfig = {
+      type: "pkcs11",
+      libraryPath: softHsmPath,
+      slotIndex: 0,
+      userPin,
+    };
+
+    try {
+      await hsm.initializeAsync({
+        slotId: "slot-0",
+        label: "PKCS#11 Demo HSM",
+        crypto: pkcs11Config,
+      });
+      console.log("[OK] PKCS#11 mode initialized successfully\n");
+    } catch (error) {
+      console.log(
+        `[WARN] PKCS#11 initialization failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      console.log("[INFO] Falling back to simulator mode...\n");
+      hsm.initialize({ slotId: "slot-0", label: "Simulator Demo HSM" });
+    }
+  } else {
+    console.log("[INFO] SoftHSM2 not found, using simulator mode...");
+    console.log("[TIP] Set HSM_LIBRARY_PATH to your PKCS#11 library path\n");
+    hsm.initialize({ slotId: "slot-0", label: "Simulator Demo HSM" });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 1. EC P-256 Key Generation and Signing
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("1. EC P-256 Key Pair (ECDSA-SHA256)");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  const ecP256Key = await hsm.generateKeyPairAsync("ec-p256-key", {
+    keyType: "EC",
+    namedCurve: "P-256",
+  });
+  console.log(`[KEY] Generated: ${ecP256Key.keyLabel}`);
+  console.log(`      Type: ${ecP256Key.keyType} ${ecP256Key.namedCurve}`);
+  console.log(`      Handle: ${ecP256Key.privateKeyHandle.slice(0, 40)}...`);
+
+  const ecP256Data = "Transaction data for EC P-256 signing";
+  const ecP256Sig = await hsm.signAsync(
+    "ec-p256-key",
+    ecP256Data,
+    "ecdsa-sha256",
+  );
+  console.log(`[SIG] Algorithm: ${ecP256Sig.algorithm}`);
+  console.log(`      Signature: ${ecP256Sig.signature.slice(0, 40)}...`);
+
+  const ecP256Valid = await hsm.verifyAsync(
+    "ec-p256-key",
+    ecP256Data,
+    ecP256Sig.signature,
+    "ecdsa-sha256",
+  );
+  console.log(`[VRF] Verification: ${ecP256Valid ? "VALID ✓" : "INVALID ✗"}\n`);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 2. EC P-384 Key Generation and Signing
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("2. EC P-384 Key Pair (ECDSA-SHA384)");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  const ecP384Key = await hsm.generateKeyPairAsync("ec-p384-key", {
+    keyType: "EC",
+    namedCurve: "P-384",
+  });
+  console.log(`[KEY] Generated: ${ecP384Key.keyLabel}`);
+  console.log(`      Type: ${ecP384Key.keyType} ${ecP384Key.namedCurve}`);
+
+  const ecP384Data = "High-security transaction for P-384";
+  const ecP384Sig = await hsm.signAsync(
+    "ec-p384-key",
+    ecP384Data,
+    "ecdsa-sha384",
+  );
+  console.log(`[SIG] Algorithm: ${ecP384Sig.algorithm}`);
+  console.log(`      Signature: ${ecP384Sig.signature.slice(0, 40)}...`);
+
+  const ecP384Valid = await hsm.verifyAsync(
+    "ec-p384-key",
+    ecP384Data,
+    ecP384Sig.signature,
+    "ecdsa-sha384",
+  );
+  console.log(`[VRF] Verification: ${ecP384Valid ? "VALID ✓" : "INVALID ✗"}\n`);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 3. Ed25519 Key Generation and EdDSA Signing
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("3. Ed25519 Key Pair (EdDSA)");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  const ed25519Key = await hsm.generateKeyPairAsync("ed25519-key", {
+    keyType: "Ed",
+    namedCurve: "Ed25519",
+  });
+  console.log(`[KEY] Generated: ${ed25519Key.keyLabel}`);
+  console.log(`      Type: ${ed25519Key.keyType} ${ed25519Key.namedCurve}`);
+
+  const edData = "Fast EdDSA signing for blockchain";
+  const edSig = await hsm.signAsync("ed25519-key", edData, "ed25519");
+  console.log(`[SIG] Algorithm: ${edSig.algorithm}`);
+  console.log(`      Signature: ${edSig.signature.slice(0, 40)}...`);
+
+  const edValid = await hsm.verifyAsync(
+    "ed25519-key",
+    edData,
+    edSig.signature,
+    "ed25519",
+  );
+  console.log(`[VRF] Verification: ${edValid ? "VALID ✓" : "INVALID ✗"}\n`);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4. RSA-4096 Key Generation and RSA-PSS Signing
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("4. RSA-4096 Key Pair (RSA-PSS-SHA256)");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  const rsaKey = await hsm.generateKeyPairAsync("rsa-4096-key", {
+    keyType: "RSA",
+    rsaBits: 4096,
+  });
+  console.log(`[KEY] Generated: ${rsaKey.keyLabel}`);
+  console.log(`      Type: ${rsaKey.keyType} ${rsaKey.rsaBits}-bit`);
+
+  const rsaData = "Document hash for RSA signing";
+  const rsaSig = await hsm.signAsync("rsa-4096-key", rsaData, "rsa-pss-sha256");
+  console.log(`[SIG] Algorithm: ${rsaSig.algorithm}`);
+  console.log(`      Signature: ${rsaSig.signature.slice(0, 40)}...`);
+
+  const rsaValid = await hsm.verifyAsync(
+    "rsa-4096-key",
+    rsaData,
+    rsaSig.signature,
+    "rsa-pss-sha256",
+  );
+  console.log(`[VRF] Verification: ${rsaValid ? "VALID ✓" : "INVALID ✗"}\n`);
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 5. AES-256 KEK and Envelope Encryption
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("5. AES-256 KEK and Envelope Encryption");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  await hsm.generateSymmetricKeyAsync("master-kek", { keyBits: 256 });
+  console.log("[KEK] Generated: master-kek (AES-256)");
+
+  const sensitiveData = JSON.stringify({
+    accountId: "ACC-123456",
+    balance: 1000000,
+    currency: "USD",
+    timestamp: new Date().toISOString(),
+  });
+
+  const encrypted = await hsm.encryptWithEnvelopeAsync(
+    "master-kek",
+    sensitiveData,
+  );
+  console.log("[ENC] Encrypted sensitive data:");
+  console.log(
+    `      Ciphertext: ${encrypted.encryptedRecord.ciphertext.slice(0, 40)}...`,
+  );
+  console.log(
+    `      Wrapped DEK: ${encrypted.wrappedDek.wrappedDek.slice(0, 40)}...`,
+  );
+
+  const decrypted = await hsm.decryptWithEnvelopeAsync(
+    encrypted.wrappedDek,
+    encrypted.encryptedRecord,
+  );
+  console.log(`[DEC] Decrypted: ${decrypted.slice(0, 50)}...`);
+  console.log(
+    `[VRF] Roundtrip: ${decrypted === sensitiveData ? "SUCCESS ✓" : "FAILED ✗"}\n`,
+  );
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 6. Audit Log
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+  console.log("6. Audit Log Summary");
+  console.log(
+    "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+  );
+
+  const auditLog = hsm.getAuditLog();
+  console.log(`[LOG] Total entries: ${auditLog.length}`);
+
+  const operations = new Map<string, number>();
+  for (const entry of auditLog) {
+    operations.set(entry.operation, (operations.get(entry.operation) ?? 0) + 1);
+  }
+
+  for (const [op, count] of operations) {
+    console.log(`      - ${op}: ${count}`);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Cleanup
+  // ─────────────────────────────────────────────────────────────────────────
+  console.log("\n[INFO] Finalizing HSM session...");
+  await hsm.finalizeAsync();
+
+  console.log(
+    "\n╔══════════════════════════════════════════════════════════════╗",
+  );
+  console.log(
+    "║                    Example Complete                          ║",
+  );
+  console.log(
+    "║                                                              ║",
+  );
+  console.log(
+    "║  All key types and operations demonstrated successfully.    ║",
+  );
+  console.log(
+    "║                                                              ║",
+  );
+  console.log(
+    "║  For real PKCS#11 HSM support:                              ║",
+  );
+  console.log(
+    "║  1. Install SoftHSM2 or use a hardware HSM                  ║",
+  );
+  console.log(
+    "║  2. Set HSM_LIBRARY_PATH and HSM_PIN environment vars       ║",
+  );
+  console.log(
+    "║  3. Use initializeAsync() with Pkcs11CryptoConfig           ║",
+  );
+  console.log(
+    "╚══════════════════════════════════════════════════════════════╝\n",
+  );
+}
+
+main().catch((error) => {
+  console.error("Example failed:", error);
+  process.exit(1);
+});

--- a/infra/softhsm2/Dockerfile
+++ b/infra/softhsm2/Dockerfile
@@ -1,0 +1,39 @@
+# SoftHSM2 Docker Image for PKCS#11 Testing
+#
+# Provides a software PKCS#11 implementation compatible with real HSM workflows.
+# Use this for CI/CD testing of HSM-dependent code without real hardware.
+#
+# Build: docker build -t softhsm2 .
+# Run:   docker run -d --name softhsm2 -v softhsm2-tokens:/var/lib/softhsm/tokens softhsm2
+
+FROM debian:bookworm-slim
+
+LABEL maintainer="Paulo Savelis"
+LABEL description="SoftHSM2 for PKCS#11 integration testing"
+
+# Install SoftHSM2 and dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    softhsm2 \
+    opensc \
+    libengine-pkcs11-openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/lib/softhsm/tokens \
+    && chmod 755 /var/lib/softhsm/tokens
+
+# Configure SoftHSM2
+RUN echo "directories.tokendir = /var/lib/softhsm/tokens\n\
+objectstore.backend = file\n\
+log.level = INFO\n\
+slots.removable = false" > /etc/softhsm/softhsm2.conf
+
+# Initialize a default token
+# SO PIN: 1234567890 (Security Officer)
+# User PIN: 1234 (Crypto User)
+RUN softhsm2-util --init-token --slot 0 --label "enterprise-blockchain" \
+    --so-pin 1234567890 --pin 1234
+
+# Volume for persistent token storage
+VOLUME /var/lib/softhsm/tokens
+
+# Default command: keep container running
+CMD ["tail", "-f", "/dev/null"]

--- a/infra/softhsm2/docker-compose.yml
+++ b/infra/softhsm2/docker-compose.yml
@@ -1,0 +1,33 @@
+# SoftHSM2 Docker Compose for PKCS#11 Integration Testing
+#
+# Usage:
+#   docker compose up -d          # Start SoftHSM2
+#   docker compose down -v        # Stop and remove volumes
+#
+# The PKCS#11 library is available at:
+#   /usr/lib/softhsm/libsofthsm2.so (inside container)
+#
+# For Node.js with graphene-pk11, mount the library:
+#   docker compose exec softhsm2 softhsm2-util --show-slots
+
+services:
+  softhsm2:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: softhsm2
+    volumes:
+      - softhsm2-tokens:/var/lib/softhsm/tokens
+      # Mount library for host access (optional, for local testing)
+      # - ./lib:/opt/softhsm2/lib
+    environment:
+      - SOFTHSM2_CONF=/etc/softhsm/softhsm2.conf
+    healthcheck:
+      test: ["CMD", "softhsm2-util", "--show-slots"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  softhsm2-tokens:

--- a/modules/hsm/src/application/asymmetric-key-service.ts
+++ b/modules/hsm/src/application/asymmetric-key-service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import {
+  constants,
   createPrivateKey,
   createPublicKey,
   createSign,
@@ -488,14 +489,20 @@ export class AsymmetricKeyService {
         signer.update(data);
         signer.end();
         return signer
-          .sign({ key: privateKey, padding: 6, saltLength: 32 })
+          .sign({
+            key: privateKey,
+            padding: constants.RSA_PKCS1_PSS_PADDING,
+            saltLength: 32,
+          })
           .toString("hex");
       }
       case "rsa-pkcs1-sha256": {
         const signer = createSign("SHA256");
         signer.update(data);
         signer.end();
-        return signer.sign({ key: privateKey, padding: 1 }).toString("hex");
+        return signer
+          .sign({ key: privateKey, padding: constants.RSA_PKCS1_PADDING })
+          .toString("hex");
       }
       default:
         throw new Error(`Unsupported signing algorithm: ${algorithm}`);
@@ -533,7 +540,11 @@ export class AsymmetricKeyService {
         verifier.update(data);
         verifier.end();
         return verifier.verify(
-          { key: publicKey, padding: 6, saltLength: 32 },
+          {
+            key: publicKey,
+            padding: constants.RSA_PKCS1_PSS_PADDING,
+            saltLength: 32,
+          },
           sigBuffer,
         );
       }
@@ -541,7 +552,10 @@ export class AsymmetricKeyService {
         const verifier = createVerify("SHA256");
         verifier.update(data);
         verifier.end();
-        return verifier.verify({ key: publicKey, padding: 1 }, sigBuffer);
+        return verifier.verify(
+          { key: publicKey, padding: constants.RSA_PKCS1_PADDING },
+          sigBuffer,
+        );
       }
       default:
         throw new Error(`Unsupported verification algorithm: ${algorithm}`);

--- a/modules/hsm/src/application/asymmetric-key-service.ts
+++ b/modules/hsm/src/application/asymmetric-key-service.ts
@@ -207,6 +207,18 @@ export class AsymmetricKeyService {
     const namedCurve = options?.namedCurve ?? "P-256";
     const rsaBits = options?.rsaBits ?? 4096;
 
+    // Validate keyType + namedCurve combinations
+    if (keyType === "EC" && !["P-256", "P-384"].includes(namedCurve)) {
+      throw new Error(
+        `Invalid curve "${namedCurve}" for EC key type. Use "P-256" or "P-384".`,
+      );
+    }
+    if (keyType === "Ed" && namedCurve !== "Ed25519") {
+      throw new Error(
+        `Invalid curve "${namedCurve}" for Ed key type. Use "Ed25519".`,
+      );
+    }
+
     const createdAt = new Date().toISOString();
     let handle: string;
     let publicKeyPem: string;

--- a/modules/hsm/src/application/asymmetric-key-service.ts
+++ b/modules/hsm/src/application/asymmetric-key-service.ts
@@ -130,6 +130,14 @@ export class AsymmetricKeyService {
     const entry = this.requireAsymmetric(keyLabel);
     const timestamp = new Date().toISOString();
 
+    // Guard: sync signing requires in-memory PEM material (simulator keys only)
+    if (!entry.privateKeyPem) {
+      throw new Error(
+        `Key "${keyLabel}" has no in-memory private key material. ` +
+          `Use signAsync() for hardware-backed keys.`,
+      );
+    }
+
     // Convert PEM back to KeyObject for signing
     const privateKey = createPrivateKey(entry.privateKeyPem);
 

--- a/modules/hsm/src/application/asymmetric-key-service.ts
+++ b/modules/hsm/src/application/asymmetric-key-service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
 import {
   createPrivateKey,
   createPublicKey,
@@ -5,32 +7,72 @@ import {
   createVerify,
   generateKeyPairSync,
   randomBytes,
+  sign,
+  verify,
 } from "node:crypto";
 
 import { sha256hex } from "../../../shared/src/crypto";
 import type {
   AsymmetricKeyEntry,
   HsmKeyPair,
+  HsmKeyType,
+  HsmNamedCurve,
+  HsmSignatureAlgorithm,
   HsmSignatureResult,
 } from "../domain/entities";
-import type { AuditLog, KeyStore } from "../domain/ports";
+import type {
+  AuditLog,
+  EcCurve,
+  EdCurve,
+  HsmCryptoPort,
+  KeyStore,
+  RsaKeySize,
+  SigningAlgorithm,
+} from "../domain/ports";
 
 /**
- * EC P-256 asymmetric operations — signing, verification, key export.
+ * Options for key generation.
+ */
+export interface KeyGenOptions {
+  /** Key type: EC, Ed, or RSA */
+  keyType?: HsmKeyType;
+  /** Named curve for EC/Ed keys */
+  namedCurve?: HsmNamedCurve;
+  /** RSA key size in bits */
+  rsaBits?: 2048 | 4096;
+}
+
+/**
+ * Asymmetric key operations — signing, verification, key export.
  *
- * Mirrors a PKCS#11 CKM_ECDSA / CKM_EC_KEY_PAIR_GEN subset.
- * Ref: PKCS#11 v3.1, §2.3.6 — https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.1/pkcs11-curr-v3.1.html
+ * Supports:
+ * - EC P-256, P-384 (ECDSA-SHA256, ECDSA-SHA384)
+ * - Ed25519 (EdDSA)
+ * - RSA-2048, RSA-4096 (RSA-PSS-SHA256, RSA-PKCS1-SHA256)
  *
- * Note: Domain entities store keys as PEM strings (infrastructure-agnostic).
- * This service converts to/from KeyObject for cryptographic operations.
+ * Mirrors PKCS#11 mechanisms:
+ * - CKM_EC_KEY_PAIR_GEN, CKM_EC_EDWARDS_KEY_PAIR_GEN, CKM_RSA_PKCS_KEY_PAIR_GEN
+ * - CKM_ECDSA_SHA256, CKM_ECDSA_SHA384, CKM_EDDSA, CKM_RSA_PKCS_PSS, CKM_RSA_PKCS
+ *
+ * Ref: PKCS#11 v3.1 — https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.1/pkcs11-curr-v3.1.html
  */
 export class AsymmetricKeyService {
   constructor(
     private readonly keyStore: KeyStore,
     private readonly audit: AuditLog,
     private readonly slotId: string,
+    /** Optional crypto port for hardware HSM support */
+    private readonly crypto?: HsmCryptoPort,
   ) {}
 
+  // ---------------------------------------------------------------------------
+  // Synchronous Methods (Backward Compatible - Simulator Only)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate EC P-256 key pair (synchronous, simulator only).
+   * For hardware HSM support, use generateKeyPairAsync().
+   */
   generateKeyPair(keyLabel: string): HsmKeyPair {
     if (this.keyStore.has(keyLabel)) {
       throw new Error(`HSM key already exists: ${keyLabel}`);
@@ -59,8 +101,10 @@ export class AsymmetricKeyService {
     this.keyStore.set(keyLabel, {
       kind: "asymmetric",
       keyLabel,
+      handle,
       privateKeyPem,
       publicKeyPem,
+      keyType: "EC",
       namedCurve: "P-256",
       createdAt,
     });
@@ -77,6 +121,10 @@ export class AsymmetricKeyService {
     };
   }
 
+  /**
+   * Sign data with EC P-256 key (synchronous, simulator only).
+   * For hardware HSM support, use signAsync().
+   */
   sign(keyLabel: string, data: string): HsmSignatureResult {
     const entry = this.requireAsymmetric(keyLabel);
     const timestamp = new Date().toISOString();
@@ -105,6 +153,10 @@ export class AsymmetricKeyService {
     };
   }
 
+  /**
+   * Verify signature (synchronous, simulator only).
+   * For hardware HSM support, use verifyAsync().
+   */
   verify(keyLabel: string, data: string, signature: string): boolean {
     const entry = this.requireAsymmetric(keyLabel);
 
@@ -125,11 +177,248 @@ export class AsymmetricKeyService {
     return valid;
   }
 
+  /**
+   * Export public key (synchronous).
+   */
   exportPublicKey(keyLabel: string): string {
     const entry = this.requireAsymmetric(keyLabel);
     this.audit.record("exportPublicKey", keyLabel, "success");
     return entry.publicKeyPem;
   }
+
+  // ---------------------------------------------------------------------------
+  // Asynchronous Methods (Hardware HSM Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate key pair asynchronously.
+   * Supports EC P-256, P-384, Ed25519, RSA-2048, RSA-4096.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   */
+  async generateKeyPairAsync(
+    keyLabel: string,
+    options?: KeyGenOptions,
+  ): Promise<HsmKeyPair> {
+    if (this.keyStore.has(keyLabel)) {
+      throw new Error(`HSM key already exists: ${keyLabel}`);
+    }
+
+    const keyType = options?.keyType ?? "EC";
+    const namedCurve = options?.namedCurve ?? "P-256";
+    const rsaBits = options?.rsaBits ?? 4096;
+
+    const createdAt = new Date().toISOString();
+    let handle: string;
+    let publicKeyPem: string;
+    let privateKeyPem = "";
+
+    if (this.crypto) {
+      // Use hardware HSM
+      let result;
+      switch (keyType) {
+        case "EC":
+          result = await this.crypto.generateEcKeyPair(namedCurve as EcCurve);
+          break;
+        case "Ed":
+          result = await this.crypto.generateEdKeyPair(namedCurve as EdCurve);
+          break;
+        case "RSA":
+          result = await this.crypto.generateRsaKeyPair(rsaBits as RsaKeySize);
+          break;
+        default:
+          throw new Error(`Unsupported key type: ${keyType}`);
+      }
+      handle = result.handle;
+      publicKeyPem = result.publicKeyPem;
+    } else {
+      // Fall back to simulator
+      if (keyType === "EC") {
+        const { privateKey, publicKey } = generateKeyPairSync("ec", {
+          namedCurve: namedCurve,
+        });
+        handle = `sim:ec:${randomBytes(8).toString("hex")}`;
+        publicKeyPem = publicKey.export({
+          type: "spki",
+          format: "pem",
+        }) as string;
+        privateKeyPem = privateKey.export({
+          type: "pkcs8",
+          format: "pem",
+        }) as string;
+      } else if (keyType === "Ed") {
+        const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+        handle = `sim:ed:${randomBytes(8).toString("hex")}`;
+        publicKeyPem = publicKey.export({
+          type: "spki",
+          format: "pem",
+        }) as string;
+        privateKeyPem = privateKey.export({
+          type: "pkcs8",
+          format: "pem",
+        }) as string;
+      } else if (keyType === "RSA") {
+        const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+          modulusLength: rsaBits,
+          publicExponent: 65537,
+        });
+        handle = `sim:rsa:${randomBytes(8).toString("hex")}`;
+        publicKeyPem = publicKey.export({
+          type: "spki",
+          format: "pem",
+        }) as string;
+        privateKeyPem = privateKey.export({
+          type: "pkcs8",
+          format: "pem",
+        }) as string;
+      } else {
+        throw new Error(`Unsupported key type: ${keyType}`);
+      }
+    }
+
+    // Build entry without undefined optional properties (exactOptionalPropertyTypes)
+    const entry: AsymmetricKeyEntry = {
+      kind: "asymmetric",
+      keyLabel,
+      handle,
+      privateKeyPem,
+      publicKeyPem,
+      keyType,
+      createdAt,
+    };
+    if (keyType !== "RSA") {
+      entry.namedCurve = namedCurve as HsmNamedCurve;
+    }
+    if (keyType === "RSA") {
+      entry.rsaBits = rsaBits;
+    }
+    this.keyStore.set(keyLabel, entry);
+
+    this.audit.record("generateKeyPair", keyLabel, "success", keyType);
+
+    // Build result without undefined optional properties (exactOptionalPropertyTypes)
+    const result: HsmKeyPair = {
+      keyLabel,
+      keyType,
+      publicKeyPem,
+      privateKeyHandle: `hsm:${this.slotId}:${keyLabel}:${handle}`,
+      createdAt,
+    };
+    if (keyType !== "RSA") {
+      result.namedCurve = namedCurve as HsmNamedCurve;
+    }
+    if (keyType === "RSA") {
+      result.rsaBits = rsaBits;
+    }
+    return result;
+  }
+
+  /**
+   * Sign data asynchronously.
+   * Supports ECDSA-SHA256, ECDSA-SHA384, Ed25519, RSA-PSS-SHA256, RSA-PKCS1-SHA256.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   */
+  async signAsync(
+    keyLabel: string,
+    data: string,
+    algorithm?: HsmSignatureAlgorithm,
+  ): Promise<HsmSignatureResult> {
+    const entry = this.requireAsymmetric(keyLabel);
+    const timestamp = new Date().toISOString();
+
+    // Determine algorithm based on key type if not specified
+    const signAlgorithm: SigningAlgorithm =
+      algorithm ?? this.getDefaultAlgorithm(entry.keyType);
+
+    let signature: string;
+
+    if (this.crypto) {
+      // Use hardware HSM
+      const sigBuffer = await this.crypto.sign(
+        entry.handle,
+        signAlgorithm,
+        Buffer.from(data),
+      );
+      signature = sigBuffer.toString("hex");
+    } else {
+      // Fall back to simulator
+      signature = this.signSync(entry, data, signAlgorithm);
+    }
+
+    const hsmAttestation = sha256hex(
+      `${this.slotId}:${keyLabel}:${timestamp}:${signature}`,
+    );
+
+    this.audit.record("sign", keyLabel, "success", signAlgorithm);
+
+    return {
+      keyLabel,
+      algorithm: signAlgorithm,
+      signature,
+      publicKeyPem: entry.publicKeyPem,
+      timestamp,
+      hsmAttestation,
+    };
+  }
+
+  /**
+   * Verify signature asynchronously.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   */
+  async verifyAsync(
+    keyLabel: string,
+    data: string,
+    signature: string,
+    algorithm?: HsmSignatureAlgorithm,
+  ): Promise<boolean> {
+    const entry = this.requireAsymmetric(keyLabel);
+
+    const verifyAlgorithm: SigningAlgorithm =
+      algorithm ?? this.getDefaultAlgorithm(entry.keyType);
+
+    let valid: boolean;
+
+    if (this.crypto) {
+      // Use hardware HSM
+      valid = await this.crypto.verify(
+        entry.handle,
+        verifyAlgorithm,
+        Buffer.from(data),
+        Buffer.from(signature, "hex"),
+      );
+    } else {
+      // Fall back to simulator
+      valid = this.verifySync(entry, data, signature, verifyAlgorithm);
+    }
+
+    this.audit.record(
+      "verify",
+      keyLabel,
+      "success",
+      valid ? "valid" : "invalid",
+    );
+    return valid;
+  }
+
+  /**
+   * Export public key asynchronously.
+   */
+  async exportPublicKeyAsync(keyLabel: string): Promise<string> {
+    const entry = this.requireAsymmetric(keyLabel);
+
+    if (this.crypto) {
+      // For PKCS#11, we might need to fetch from HSM
+      const pem = await this.crypto.exportPublicKey(entry.handle);
+      this.audit.record("exportPublicKey", keyLabel, "success");
+      return pem;
+    }
+
+    this.audit.record("exportPublicKey", keyLabel, "success");
+    return entry.publicKeyPem;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
 
   private requireAsymmetric(keyLabel: string): AsymmetricKeyEntry {
     const entry = this.keyStore.get(keyLabel);
@@ -142,5 +431,108 @@ export class AsymmetricKeyService {
       throw new Error(`HSM key '${keyLabel}' is not an asymmetric key`);
     }
     return entry;
+  }
+
+  private getDefaultAlgorithm(keyType: HsmKeyType): SigningAlgorithm {
+    switch (keyType) {
+      case "EC":
+        return "ecdsa-sha256";
+      case "Ed":
+        return "ed25519";
+      case "RSA":
+        return "rsa-pss-sha256";
+      default:
+        return "ecdsa-sha256";
+    }
+  }
+
+  private signSync(
+    entry: AsymmetricKeyEntry,
+    data: string,
+    algorithm: SigningAlgorithm,
+  ): string {
+    const privateKey = createPrivateKey(entry.privateKeyPem);
+
+    switch (algorithm) {
+      case "ecdsa-sha256": {
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer.sign(privateKey).toString("hex");
+      }
+      case "ecdsa-sha384": {
+        const signer = createSign("SHA384");
+        signer.update(data);
+        signer.end();
+        return signer.sign(privateKey).toString("hex");
+      }
+      case "ed25519": {
+        // Ed25519 uses crypto.sign() directly, not createSign()
+        const signature = sign(null, Buffer.from(data), privateKey);
+        return signature.toString("hex");
+      }
+      case "rsa-pss-sha256": {
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer
+          .sign({ key: privateKey, padding: 6, saltLength: 32 })
+          .toString("hex");
+      }
+      case "rsa-pkcs1-sha256": {
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer.sign({ key: privateKey, padding: 1 }).toString("hex");
+      }
+      default:
+        throw new Error(`Unsupported signing algorithm: ${algorithm}`);
+    }
+  }
+
+  private verifySync(
+    entry: AsymmetricKeyEntry,
+    data: string,
+    signature: string,
+    algorithm: SigningAlgorithm,
+  ): boolean {
+    const publicKey = createPublicKey(entry.publicKeyPem);
+    const sigBuffer = Buffer.from(signature, "hex");
+
+    switch (algorithm) {
+      case "ecdsa-sha256": {
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(publicKey, sigBuffer);
+      }
+      case "ecdsa-sha384": {
+        const verifier = createVerify("SHA384");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(publicKey, sigBuffer);
+      }
+      case "ed25519": {
+        // Ed25519 uses crypto.verify() directly, not createVerify()
+        return verify(null, Buffer.from(data), publicKey, sigBuffer);
+      }
+      case "rsa-pss-sha256": {
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(
+          { key: publicKey, padding: 6, saltLength: 32 },
+          sigBuffer,
+        );
+      }
+      case "rsa-pkcs1-sha256": {
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify({ key: publicKey, padding: 1 }, sigBuffer);
+      }
+      default:
+        throw new Error(`Unsupported verification algorithm: ${algorithm}`);
+    }
   }
 }

--- a/modules/hsm/src/application/envelope-encryption-service.ts
+++ b/modules/hsm/src/application/envelope-encryption-service.ts
@@ -14,6 +14,10 @@ import type { SymmetricKeyService } from "./symmetric-key-service";
  * The resulting ciphertext is suitable for storage on a distributed ledger:
  *  - encryptedRecord  = AES-256-GCM ciphertext of the payload
  *  - wrappedDek       = GCM-wrapped DEK (only the HSM can unwrap it)
+ *
+ * Supports two modes:
+ * - Simulator (default): Uses node:crypto for key operations
+ * - PKCS#11: Uses hardware HSM via SymmetricKeyService async methods
  */
 export class EnvelopeEncryptionService {
   constructor(
@@ -21,6 +25,14 @@ export class EnvelopeEncryptionService {
     private readonly audit: AuditLog,
   ) {}
 
+  // ---------------------------------------------------------------------------
+  // Synchronous Methods (Backward Compatible - Simulator Only)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Encrypt with envelope encryption (synchronous, simulator only).
+   * For hardware HSM support, use encryptAsync().
+   */
   encrypt(kekLabel: string, plaintext: string): EnvelopeEncryptionResult {
     const dek = randomBytes(32);
 
@@ -46,8 +58,86 @@ export class EnvelopeEncryptionService {
     return { encryptedRecord, wrappedDek };
   }
 
+  /**
+   * Decrypt with envelope encryption (synchronous, simulator only).
+   * For hardware HSM support, use decryptAsync().
+   */
   decrypt(wrappedDek: WrappedKey, encryptedRecord: EncryptedRecord): string {
     const dek = this.symmetric.unwrapKey(wrappedDek);
+
+    const iv = Buffer.from(encryptedRecord.iv, "hex");
+    const authTag = Buffer.from(encryptedRecord.authTag, "hex");
+    const ciphertext = Buffer.from(encryptedRecord.ciphertext, "hex");
+
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", dek, iv);
+      decipher.setAuthTag(authTag);
+      const plaintext = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]).toString("utf8");
+      this.audit.record("decryptWithEnvelope", wrappedDek.kekLabel, "success");
+      return plaintext;
+    } catch {
+      this.audit.record(
+        "decryptWithEnvelope",
+        wrappedDek.kekLabel,
+        "failed",
+        "GCM authentication failed",
+      );
+      throw new Error("HSM decryptWithEnvelope: GCM authentication failed");
+    } finally {
+      dek.fill(0);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Asynchronous Methods (Hardware HSM Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Encrypt with envelope encryption asynchronously.
+   * Uses SymmetricKeyService.wrapKeyAsync() for hardware HSM support.
+   */
+  async encryptAsync(
+    kekLabel: string,
+    plaintext: string,
+  ): Promise<EnvelopeEncryptionResult> {
+    const dek = randomBytes(32);
+
+    const payloadIv = randomBytes(12);
+    const payloadCipher = createCipheriv("aes-256-gcm", dek, payloadIv);
+    const ciphertextBuf = Buffer.concat([
+      payloadCipher.update(plaintext, "utf8"),
+      payloadCipher.final(),
+    ]);
+    const payloadAuthTag = payloadCipher.getAuthTag();
+
+    const encryptedRecord: EncryptedRecord = {
+      ciphertext: ciphertextBuf.toString("hex"),
+      iv: payloadIv.toString("hex"),
+      authTag: payloadAuthTag.toString("hex"),
+      algorithm: "aes-256-gcm",
+    };
+
+    // Use async wrap for PKCS#11 support
+    const wrappedDek = await this.symmetric.wrapKeyAsync(dek, kekLabel);
+    dek.fill(0);
+
+    this.audit.record("encryptWithEnvelope", kekLabel, "success");
+    return { encryptedRecord, wrappedDek };
+  }
+
+  /**
+   * Decrypt with envelope encryption asynchronously.
+   * Uses SymmetricKeyService.unwrapKeyAsync() for hardware HSM support.
+   */
+  async decryptAsync(
+    wrappedDek: WrappedKey,
+    encryptedRecord: EncryptedRecord,
+  ): Promise<string> {
+    // Use async unwrap for PKCS#11 support
+    const dek = await this.symmetric.unwrapKeyAsync(wrappedDek);
 
     const iv = Buffer.from(encryptedRecord.iv, "hex");
     const authTag = Buffer.from(encryptedRecord.authTag, "hex");

--- a/modules/hsm/src/application/symmetric-key-service.ts
+++ b/modules/hsm/src/application/symmetric-key-service.ts
@@ -1,7 +1,20 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 
 import type { SymmetricKeyEntry, WrappedKey } from "../domain/entities";
-import type { AuditLog, KeyStore } from "../domain/ports";
+import type {
+  AesKeySize,
+  AuditLog,
+  HsmCryptoPort,
+  KeyStore,
+} from "../domain/ports";
+
+/**
+ * Options for symmetric key generation.
+ */
+export interface SymmetricKeyGenOptions {
+  /** Key size in bits: 128 or 256 (default: 256) */
+  keyBits?: AesKeySize;
+}
 
 /**
  * AES-256-GCM symmetric operations — key generation, wrapping, unwrapping.
@@ -12,22 +25,44 @@ import type { AuditLog, KeyStore } from "../domain/ports";
  *
  * SECURITY: Intermediate key buffers are zeroized after use to minimize
  * key material exposure in memory.
+ *
+ * Supports two modes:
+ * - Simulator (default): Uses node:crypto for key operations
+ * - PKCS#11: Uses hardware HSM via HsmCryptoPort for real key protection
+ *
+ * Mirrors PKCS#11 mechanisms:
+ * - CKM_AES_KEY_GEN
+ * - CKM_AES_GCM (for wrapping/unwrapping)
  */
 export class SymmetricKeyService {
   constructor(
     private readonly keyStore: KeyStore,
     private readonly audit: AuditLog,
+    /** Optional crypto port for hardware HSM support */
+    private readonly crypto?: HsmCryptoPort,
   ) {}
 
+  // ---------------------------------------------------------------------------
+  // Synchronous Methods (Backward Compatible - Simulator Only)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate AES-256 symmetric key (synchronous, simulator only).
+   * For hardware HSM support, use generateSymmetricKeyAsync().
+   */
   generateSymmetricKey(keyLabel: string): void {
     if (this.keyStore.has(keyLabel)) {
       throw new Error(`HSM key already exists: ${keyLabel}`);
     }
+    const keyBytes = randomBytes(32);
+    const handle = `sim:aes:${randomBytes(8).toString("hex")}`;
+
     this.keyStore.set(keyLabel, {
       kind: "symmetric",
       keyLabel,
-      // Buffer is a Uint8Array subclass; no copy needed
-      keyBytes: randomBytes(32),
+      handle,
+      keyBytes,
+      keyBits: 256,
       createdAt: new Date().toISOString(),
     });
     this.audit.record("generateSymmetricKey", keyLabel, "success");
@@ -35,6 +70,7 @@ export class SymmetricKeyService {
 
   /**
    * Wrap a DEK (data encryption key) using the KEK (key encryption key).
+   * Synchronous version for simulator only. For hardware HSM, use wrapKeyAsync().
    *
    * SECURITY: The kekBuffer is zeroized after use.
    */
@@ -69,6 +105,7 @@ export class SymmetricKeyService {
 
   /**
    * Unwrap a DEK using the KEK.
+   * Synchronous version for simulator only. For hardware HSM, use unwrapKeyAsync().
    *
    * SECURITY: The kekBuffer is zeroized after use.
    * CALLER RESPONSIBILITY: The returned DEK buffer MUST be zeroized
@@ -103,6 +140,208 @@ export class SymmetricKeyService {
       kekBuffer.fill(0);
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Asynchronous Methods (Hardware HSM Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate symmetric key asynchronously.
+   * Supports AES-128 and AES-256.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   */
+  async generateSymmetricKeyAsync(
+    keyLabel: string,
+    options?: SymmetricKeyGenOptions,
+  ): Promise<void> {
+    if (this.keyStore.has(keyLabel)) {
+      throw new Error(`HSM key already exists: ${keyLabel}`);
+    }
+
+    const keyBits = options?.keyBits ?? 256;
+    const createdAt = new Date().toISOString();
+    let handle: string;
+    let keyBytes: Uint8Array;
+
+    if (this.crypto) {
+      // Use hardware HSM - key never leaves hardware
+      handle = await this.crypto.generateAesKey(keyBits);
+      keyBytes = new Uint8Array(0); // Empty for PKCS#11
+    } else {
+      // Fall back to simulator
+      keyBytes = randomBytes(keyBits / 8);
+      handle = `sim:aes:${randomBytes(8).toString("hex")}`;
+    }
+
+    this.keyStore.set(keyLabel, {
+      kind: "symmetric",
+      keyLabel,
+      handle,
+      keyBytes,
+      keyBits,
+      createdAt,
+    });
+
+    this.audit.record(
+      "generateSymmetricKey",
+      keyLabel,
+      "success",
+      `${keyBits}-bit`,
+    );
+  }
+
+  /**
+   * Wrap a DEK using the KEK asynchronously.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   *
+   * SECURITY: For simulator mode, kekBuffer is zeroized after use.
+   */
+  async wrapKeyAsync(
+    plaintextDek: Buffer,
+    kekLabel: string,
+  ): Promise<WrappedKey> {
+    const kek = this.requireSymmetric(kekLabel);
+    const wrappedAt = new Date().toISOString();
+
+    if (this.crypto) {
+      // Use hardware HSM
+      const result = await this.crypto.wrapKey(plaintextDek, kek.handle);
+
+      this.audit.record("wrapKey", kekLabel, "success");
+
+      return {
+        algorithm: "aes-256-gcm",
+        wrappedDek: result.wrappedDek.toString("hex"),
+        iv: result.iv.toString("hex"),
+        authTag: result.authTag.toString("hex"),
+        kekLabel,
+        wrappedAt,
+      };
+    }
+
+    // Fall back to simulator (same as sync version)
+    const kekBuffer = Buffer.from(kek.keyBytes);
+    const iv = randomBytes(12);
+
+    try {
+      const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+      const wrappedDek = Buffer.concat([
+        cipher.update(plaintextDek),
+        cipher.final(),
+      ]);
+      const authTag = cipher.getAuthTag();
+
+      this.audit.record("wrapKey", kekLabel, "success");
+
+      return {
+        algorithm: "aes-256-gcm",
+        wrappedDek: wrappedDek.toString("hex"),
+        iv: iv.toString("hex"),
+        authTag: authTag.toString("hex"),
+        kekLabel,
+        wrappedAt,
+      };
+    } finally {
+      kekBuffer.fill(0);
+    }
+  }
+
+  /**
+   * Unwrap a DEK using the KEK asynchronously.
+   * Uses HsmCryptoPort if available, otherwise falls back to simulator.
+   *
+   * SECURITY: For simulator mode, kekBuffer is zeroized after use.
+   * CALLER RESPONSIBILITY: The returned DEK buffer MUST be zeroized
+   * after use via `dekBuffer.fill(0)`.
+   */
+  async unwrapKeyAsync(wrapped: WrappedKey): Promise<Buffer> {
+    const kek = this.requireSymmetric(wrapped.kekLabel);
+    const iv = Buffer.from(wrapped.iv, "hex");
+    const authTag = Buffer.from(wrapped.authTag, "hex");
+    const wrappedBuf = Buffer.from(wrapped.wrappedDek, "hex");
+
+    if (this.crypto) {
+      // Use hardware HSM
+      try {
+        const plaintext = await this.crypto.unwrapKey(
+          wrappedBuf,
+          iv,
+          authTag,
+          kek.handle,
+        );
+        this.audit.record("unwrapKey", wrapped.kekLabel, "success");
+        return plaintext;
+      } catch {
+        this.audit.record(
+          "unwrapKey",
+          wrapped.kekLabel,
+          "failed",
+          "GCM authentication failed",
+        );
+        throw new Error("HSM unwrapKey: GCM authentication failed");
+      }
+    }
+
+    // Fall back to simulator (same as sync version)
+    const kekBuffer = Buffer.from(kek.keyBytes);
+
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+      decipher.setAuthTag(authTag);
+      const plaintext = Buffer.concat([
+        decipher.update(wrappedBuf),
+        decipher.final(),
+      ]);
+      this.audit.record("unwrapKey", wrapped.kekLabel, "success");
+      return plaintext;
+    } catch {
+      this.audit.record(
+        "unwrapKey",
+        wrapped.kekLabel,
+        "failed",
+        "GCM authentication failed",
+      );
+      throw new Error("HSM unwrapKey: GCM authentication failed");
+    } finally {
+      kekBuffer.fill(0);
+    }
+  }
+
+  /**
+   * Check if a symmetric key exists.
+   */
+  hasKey(keyLabel: string): boolean {
+    const entry = this.keyStore.get(keyLabel);
+    return entry !== undefined && entry.kind === "symmetric";
+  }
+
+  /**
+   * Destroy a symmetric key.
+   * Securely zeroizes the key material before deletion.
+   */
+  async destroyKeyAsync(keyLabel: string): Promise<void> {
+    const entry = this.keyStore.get(keyLabel);
+    if (!entry || entry.kind !== "symmetric") {
+      return; // Key doesn't exist or not symmetric
+    }
+
+    // Zeroize key bytes if present
+    if (entry.keyBytes && entry.keyBytes.length > 0) {
+      entry.keyBytes.fill(0);
+    }
+
+    // Destroy in hardware HSM if available
+    if (this.crypto && this.crypto.destroyKey) {
+      await this.crypto.destroyKey(entry.handle);
+    }
+
+    this.keyStore.delete(keyLabel);
+    this.audit.record("destroyKey", keyLabel, "success");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
 
   requireSymmetric(kekLabel: string): SymmetricKeyEntry {
     const entry = this.keyStore.get(kekLabel);

--- a/modules/hsm/src/application/symmetric-key-service.ts
+++ b/modules/hsm/src/application/symmetric-key-service.ts
@@ -211,8 +211,9 @@ export class SymmetricKeyService {
     const algorithm =
       kek.keyBits === 128 ? "aes-128-gcm" : ("aes-256-gcm" as const);
 
-    if (this.crypto) {
-      // Use hardware HSM
+    // Use hardware HSM only if crypto port exists AND key is hardware-backed
+    // (keyBytes is empty for hardware keys, populated for simulator/sync keys)
+    if (this.crypto && kek.keyBytes.length === 0) {
       const result = await this.crypto.wrapKey(plaintextDek, kek.handle);
 
       this.audit.record("wrapKey", kekLabel, "success");
@@ -227,7 +228,7 @@ export class SymmetricKeyService {
       };
     }
 
-    // Fall back to simulator (same as sync version)
+    // Use software implementation for simulator/sync-created keys
     const kekBuffer = Buffer.from(kek.keyBytes);
     const iv = randomBytes(12);
 
@@ -268,8 +269,9 @@ export class SymmetricKeyService {
     const authTag = Buffer.from(wrapped.authTag, "hex");
     const wrappedBuf = Buffer.from(wrapped.wrappedDek, "hex");
 
-    if (this.crypto) {
-      // Use hardware HSM
+    // Use hardware HSM only if crypto port exists AND key is hardware-backed
+    // (keyBytes is empty for hardware keys, populated for simulator/sync keys)
+    if (this.crypto && kek.keyBytes.length === 0) {
       try {
         const plaintext = await this.crypto.unwrapKey(
           wrappedBuf,
@@ -290,7 +292,7 @@ export class SymmetricKeyService {
       }
     }
 
-    // Fall back to simulator (same as sync version)
+    // Use software implementation for simulator/sync-created keys
     const kekBuffer = Buffer.from(kek.keyBytes);
     // Select algorithm based on key size
     const algorithm = kek.keyBits === 128 ? "aes-128-gcm" : "aes-256-gcm";

--- a/modules/hsm/src/application/symmetric-key-service.ts
+++ b/modules/hsm/src/application/symmetric-key-service.ts
@@ -202,6 +202,9 @@ export class SymmetricKeyService {
   ): Promise<WrappedKey> {
     const kek = this.requireSymmetric(kekLabel);
     const wrappedAt = new Date().toISOString();
+    // Select algorithm based on key size
+    const algorithm =
+      kek.keyBits === 128 ? "aes-128-gcm" : ("aes-256-gcm" as const);
 
     if (this.crypto) {
       // Use hardware HSM
@@ -210,7 +213,7 @@ export class SymmetricKeyService {
       this.audit.record("wrapKey", kekLabel, "success");
 
       return {
-        algorithm: "aes-256-gcm",
+        algorithm,
         wrappedDek: result.wrappedDek.toString("hex"),
         iv: result.iv.toString("hex"),
         authTag: result.authTag.toString("hex"),
@@ -224,7 +227,7 @@ export class SymmetricKeyService {
     const iv = randomBytes(12);
 
     try {
-      const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+      const cipher = createCipheriv(algorithm, kekBuffer, iv);
       const wrappedDek = Buffer.concat([
         cipher.update(plaintextDek),
         cipher.final(),
@@ -234,7 +237,7 @@ export class SymmetricKeyService {
       this.audit.record("wrapKey", kekLabel, "success");
 
       return {
-        algorithm: "aes-256-gcm",
+        algorithm,
         wrappedDek: wrappedDek.toString("hex"),
         iv: iv.toString("hex"),
         authTag: authTag.toString("hex"),
@@ -284,9 +287,11 @@ export class SymmetricKeyService {
 
     // Fall back to simulator (same as sync version)
     const kekBuffer = Buffer.from(kek.keyBytes);
+    // Select algorithm based on key size
+    const algorithm = kek.keyBits === 128 ? "aes-128-gcm" : "aes-256-gcm";
 
     try {
-      const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+      const decipher = createDecipheriv(algorithm, kekBuffer, iv);
       decipher.setAuthTag(authTag);
       const plaintext = Buffer.concat([
         decipher.update(wrappedBuf),

--- a/modules/hsm/src/application/symmetric-key-service.ts
+++ b/modules/hsm/src/application/symmetric-key-service.ts
@@ -17,7 +17,8 @@ export interface SymmetricKeyGenOptions {
 }
 
 /**
- * AES-256-GCM symmetric operations — key generation, wrapping, unwrapping.
+ * AES-GCM symmetric operations — key generation, wrapping, unwrapping.
+ * Supports both AES-128 and AES-256 key sizes.
  *
  * The raw key is stored as Uint8Array in the domain entity to enable
  * explicit zeroization. In a production HSM the key never leaves

--- a/modules/hsm/src/application/symmetric-key-service.ts
+++ b/modules/hsm/src/application/symmetric-key-service.ts
@@ -78,9 +78,12 @@ export class SymmetricKeyService {
     const kek = this.requireSymmetric(kekLabel);
     const kekBuffer = Buffer.from(kek.keyBytes);
     const iv = randomBytes(12);
+    // Select algorithm based on key size
+    const algorithm =
+      kek.keyBits === 128 ? "aes-128-gcm" : ("aes-256-gcm" as const);
 
     try {
-      const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+      const cipher = createCipheriv(algorithm, kekBuffer, iv);
       const wrappedDek = Buffer.concat([
         cipher.update(plaintextDek),
         cipher.final(),
@@ -90,7 +93,7 @@ export class SymmetricKeyService {
       this.audit.record("wrapKey", kekLabel, "success");
 
       return {
-        algorithm: "aes-256-gcm",
+        algorithm,
         wrappedDek: wrappedDek.toString("hex"),
         iv: iv.toString("hex"),
         authTag: authTag.toString("hex"),
@@ -117,9 +120,11 @@ export class SymmetricKeyService {
     const iv = Buffer.from(wrapped.iv, "hex");
     const authTag = Buffer.from(wrapped.authTag, "hex");
     const wrappedBuf = Buffer.from(wrapped.wrappedDek, "hex");
+    // Use algorithm from wrapped key metadata
+    const algorithm = wrapped.algorithm;
 
     try {
-      const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+      const decipher = createDecipheriv(algorithm, kekBuffer, iv);
       decipher.setAuthTag(authTag);
       const plaintext = Buffer.concat([
         decipher.update(wrappedBuf),

--- a/modules/hsm/src/domain/entities.ts
+++ b/modules/hsm/src/domain/entities.ts
@@ -54,7 +54,7 @@ export interface HsmSignatureResult {
 }
 
 export interface WrappedKey {
-  algorithm: "aes-256-gcm";
+  algorithm: "aes-128-gcm" | "aes-256-gcm";
   wrappedDek: string;
   iv: string;
   authTag: string;
@@ -110,9 +110,10 @@ export interface AsymmetricKeyEntry {
   kind: "asymmetric";
   keyLabel: string;
   /**
-   * Opaque handle for the crypto adapter.
+   * Opaque adapter-specific identifier for the private key.
    * For simulator: internal ID like "sim:ec:1"
-   * For PKCS#11: hex-encoded object handle
+   * For PKCS#11: adapter-managed opaque string identifier (e.g., "pkcs11:ec:1");
+   * callers must not assume this is the raw PKCS#11 object handle.
    */
   handle: string;
   /**
@@ -135,9 +136,10 @@ export interface SymmetricKeyEntry {
   kind: "symmetric";
   keyLabel: string;
   /**
-   * Opaque handle for the crypto adapter.
+   * Opaque adapter-specific identifier for the symmetric key.
    * For simulator: internal ID like "sim:aes:1"
-   * For PKCS#11: hex-encoded object handle
+   * For PKCS#11: adapter-managed opaque string identifier;
+   * callers must not assume this is the raw PKCS#11 object handle.
    */
   handle: string;
   /**

--- a/modules/hsm/src/domain/entities.ts
+++ b/modules/hsm/src/domain/entities.ts
@@ -13,18 +13,40 @@ export interface HsmSlotConfig {
   label: string;
 }
 
+/**
+ * Key types supported by the HSM.
+ */
+export type HsmKeyType = "EC" | "Ed" | "RSA";
+
+/**
+ * Named curves for EC and Ed keys.
+ */
+export type HsmNamedCurve = "P-256" | "P-384" | "Ed25519";
+
 export interface HsmKeyPair {
   keyLabel: string;
-  keyType: "EC";
-  namedCurve: "P-256";
+  keyType: HsmKeyType;
+  namedCurve?: HsmNamedCurve;
+  /** RSA key size in bits (only for RSA keys) */
+  rsaBits?: 2048 | 4096;
   publicKeyPem: string;
   privateKeyHandle: string;
   createdAt: string;
 }
 
+/**
+ * Signature algorithms supported for HsmSignatureResult.
+ */
+export type HsmSignatureAlgorithm =
+  | "ecdsa-sha256"
+  | "ecdsa-sha384"
+  | "ed25519"
+  | "rsa-pss-sha256"
+  | "rsa-pkcs1-sha256";
+
 export interface HsmSignatureResult {
   keyLabel: string;
-  algorithm: "ecdsa-sha256";
+  algorithm: HsmSignatureAlgorithm;
   signature: string;
   publicKeyPem: string;
   timestamp: string;
@@ -80,15 +102,32 @@ export interface AsymmetricKeyHandle {
  * Uses PEM strings instead of KeyObject to keep domain types
  * infrastructure-agnostic. The infrastructure layer converts
  * to/from KeyObject as needed.
+ *
+ * For PKCS#11 backend, privateKeyPem is empty and handle references
+ * the key object on the HSM.
  */
 export interface AsymmetricKeyEntry {
   kind: "asymmetric";
   keyLabel: string;
-  /** PEM-encoded private key */
+  /**
+   * Opaque handle for the crypto adapter.
+   * For simulator: internal ID like "sim:ec:1"
+   * For PKCS#11: hex-encoded object handle
+   */
+  handle: string;
+  /**
+   * PEM-encoded private key (simulator only).
+   * Empty string for PKCS#11 where keys never leave hardware.
+   */
   privateKeyPem: string;
-  /** PEM-encoded public key */
+  /** PEM-encoded public key (SPKI format) */
   publicKeyPem: string;
-  namedCurve: "P-256";
+  /** Key type: EC, Ed, or RSA */
+  keyType: HsmKeyType;
+  /** Named curve for EC/Ed keys */
+  namedCurve?: HsmNamedCurve;
+  /** RSA key size in bits (only for RSA keys) */
+  rsaBits?: 2048 | 4096;
   createdAt: string;
 }
 
@@ -96,7 +135,13 @@ export interface SymmetricKeyEntry {
   kind: "symmetric";
   keyLabel: string;
   /**
-   * Raw key material as a byte array.
+   * Opaque handle for the crypto adapter.
+   * For simulator: internal ID like "sim:aes:1"
+   * For PKCS#11: hex-encoded object handle
+   */
+  handle: string;
+  /**
+   * Raw key material as a byte array (simulator only).
    *
    * Using Uint8Array instead of a base64 string enables explicit zeroization
    * of in-memory key material. The infrastructure layer handles encoding/decoding
@@ -106,8 +151,12 @@ export interface SymmetricKeyEntry {
    * by the key store. Callers MUST NOT mutate or zeroize this buffer directly.
    * Instead, create an ephemeral copy (e.g. `const key = Buffer.from(entry.keyBytes);`)
    * for cryptographic operations, and securely zeroize that ephemeral copy after use.
+   *
+   * For PKCS#11: This will be an empty Uint8Array since keys never leave hardware.
    */
   keyBytes: Uint8Array;
+  /** Key size in bits */
+  keyBits: 128 | 256;
   createdAt: string;
 }
 

--- a/modules/hsm/src/domain/ports.ts
+++ b/modules/hsm/src/domain/ports.ts
@@ -7,6 +7,7 @@ export interface KeyStore {
   has(label: string): boolean;
   get(label: string): KeyEntry | undefined;
   set(label: string, entry: KeyEntry): void;
+  delete(label: string): boolean;
 }
 
 /**
@@ -24,3 +25,260 @@ export interface AuditLog {
   ): void;
   entries(): readonly HsmAuditEntry[];
 }
+
+// ---------------------------------------------------------------------------
+// HSM Crypto Port — abstracts crypto backend (simulator vs real PKCS#11)
+// ---------------------------------------------------------------------------
+
+/**
+ * Signing algorithms supported by the HSM crypto port.
+ *
+ * Maps to PKCS#11 mechanisms:
+ * - ecdsa-sha256: CKM_ECDSA_SHA256 (EC P-256, P-384)
+ * - ecdsa-sha384: CKM_ECDSA_SHA384 (EC P-384)
+ * - ed25519: CKM_EDDSA (Ed25519 pure EdDSA)
+ * - rsa-pss-sha256: CKM_RSA_PKCS_PSS with SHA-256
+ * - rsa-pkcs1-sha256: CKM_RSA_PKCS with SHA-256 (legacy)
+ */
+export type SigningAlgorithm =
+  | "ecdsa-sha256"
+  | "ecdsa-sha384"
+  | "ed25519"
+  | "rsa-pss-sha256"
+  | "rsa-pkcs1-sha256";
+
+/**
+ * Elliptic curve types for key generation.
+ */
+export type EcCurve = "P-256" | "P-384";
+
+/**
+ * Edwards curve types for EdDSA key generation.
+ */
+export type EdCurve = "Ed25519";
+
+/**
+ * RSA key sizes in bits.
+ */
+export type RsaKeySize = 2048 | 4096;
+
+/**
+ * AES key sizes in bits.
+ */
+export type AesKeySize = 128 | 256;
+
+/**
+ * Key generation result with opaque handle and public key.
+ */
+export interface KeyGenerationResult {
+  /** Opaque handle for referencing the key in subsequent operations */
+  handle: string;
+  /** PEM-encoded public key (SPKI format) */
+  publicKeyPem: string;
+}
+
+/**
+ * Result of AES-GCM key wrapping operation.
+ */
+export interface WrapKeyResult {
+  /** Wrapped (encrypted) DEK */
+  wrappedDek: Buffer;
+  /** Initialization vector used for wrapping */
+  iv: Buffer;
+  /** GCM authentication tag */
+  authTag: Buffer;
+}
+
+/**
+ * Port for HSM cryptographic operations.
+ *
+ * Abstracts the crypto backend to support both:
+ * - Software simulator (node:crypto) for development/testing
+ * - Real PKCS#11 hardware HSMs (Thales, Utimaco, SafeNet, AWS CloudHSM, etc.)
+ *
+ * Supports full key suite: EC P-256/P-384, Ed25519, RSA-2048/4096, AES-128/256
+ *
+ * Ref: PKCS#11 v3.1 — https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.1/pkcs11-curr-v3.1.html
+ */
+export interface HsmCryptoPort {
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Initialize the crypto backend.
+   * For PKCS#11: loads library, opens session, logs in.
+   * For simulator: no-op.
+   */
+  initialize(config: HsmCryptoConfig): Promise<void>;
+
+  /**
+   * Finalize the crypto backend.
+   * For PKCS#11: logs out, closes session, finalizes module.
+   * For simulator: zeroizes in-memory keys.
+   */
+  finalize(): Promise<void>;
+
+  // ---------------------------------------------------------------------------
+  // Asymmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate EC key pair (P-256 or P-384).
+   * PKCS#11: CKM_EC_KEY_PAIR_GEN
+   */
+  generateEcKeyPair(curve: EcCurve): Promise<KeyGenerationResult>;
+
+  /**
+   * Generate Edwards curve key pair (Ed25519).
+   * PKCS#11: CKM_EC_EDWARDS_KEY_PAIR_GEN
+   */
+  generateEdKeyPair(curve: EdCurve): Promise<KeyGenerationResult>;
+
+  /**
+   * Generate RSA key pair (2048 or 4096 bits).
+   * PKCS#11: CKM_RSA_PKCS_KEY_PAIR_GEN
+   */
+  generateRsaKeyPair(bits: RsaKeySize): Promise<KeyGenerationResult>;
+
+  // ---------------------------------------------------------------------------
+  // Symmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate AES key (128 or 256 bits).
+   * PKCS#11: CKM_AES_KEY_GEN
+   * @returns Opaque handle for the generated key
+   */
+  generateAesKey(bits: AesKeySize): Promise<string>;
+
+  // ---------------------------------------------------------------------------
+  // Signing Operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Sign data using the specified algorithm.
+   * PKCS#11: CKM_ECDSA_SHA256, CKM_EDDSA, CKM_RSA_PKCS_PSS, etc.
+   */
+  sign(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+  ): Promise<Buffer>;
+
+  /**
+   * Verify signature using the specified algorithm.
+   */
+  verify(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+    signature: Buffer,
+  ): Promise<boolean>;
+
+  // ---------------------------------------------------------------------------
+  // Key Export
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Export public key in PEM format (SPKI).
+   * Private keys are never exported from HSM.
+   */
+  exportPublicKey(keyHandle: string): Promise<string>;
+
+  // ---------------------------------------------------------------------------
+  // Key Wrapping (Envelope Encryption)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Wrap a DEK using a KEK with AES-GCM.
+   * PKCS#11: CKM_AES_GCM
+   */
+  wrapKey(dekBytes: Buffer, kekHandle: string): Promise<WrapKeyResult>;
+
+  /**
+   * Unwrap a DEK using a KEK with AES-GCM.
+   * PKCS#11: CKM_AES_GCM
+   */
+  unwrapKey(
+    wrappedDek: Buffer,
+    iv: Buffer,
+    authTag: Buffer,
+    kekHandle: string,
+  ): Promise<Buffer>;
+
+  // ---------------------------------------------------------------------------
+  // Key Management (Optional)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Destroy a key by handle.
+   * PKCS#11: C_DestroyObject
+   */
+  destroyKey?(handle: string): Promise<void>;
+
+  /**
+   * Check if a key exists by handle.
+   */
+  hasKey?(handle: string): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// HSM Crypto Configuration
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the software simulator backend.
+ */
+export interface SimulatorCryptoConfig {
+  type: "simulator";
+}
+
+/**
+ * Configuration for real PKCS#11 hardware HSM backend.
+ *
+ * Security: Never hardcode PINs — use environment variables or secret managers.
+ */
+export interface Pkcs11CryptoConfig {
+  type: "pkcs11";
+  /**
+   * Path to the PKCS#11 library (.so on Linux, .dll on Windows, .dylib on macOS).
+   *
+   * Examples:
+   * - Thales nShield: /opt/nfast/toolkits/pkcs11/libcknfast.so
+   * - Utimaco: /opt/utimaco/lib/libcs2_pkcs11.so
+   * - SafeNet Luna: /usr/safenet/lunaclient/lib/libCryptoki2.so
+   * - AWS CloudHSM: /opt/cloudhsm/lib/libcloudhsm_pkcs11.so
+   * - SoftHSM2: /usr/lib/softhsm/libsofthsm2.so
+   */
+  libraryPath: string;
+  /**
+   * Slot index to use. Default: 0
+   * Mutually exclusive with tokenLabel.
+   */
+  slotIndex?: number;
+  /**
+   * Token label to find the slot. Takes precedence over slotIndex.
+   * Useful when slot indices change between restarts.
+   */
+  tokenLabel?: string;
+  /**
+   * User PIN for login (CKU_USER).
+   * Security: Use process.env.HSM_USER_PIN instead of hardcoding.
+   */
+  userPin: string;
+  /**
+   * Security Officer PIN (CKU_SO). Optional, used for token initialization.
+   */
+  soPin?: string;
+  /**
+   * Open read-only session. Default: false (read-write).
+   * Use true when only signing/verification is needed.
+   */
+  readOnly?: boolean;
+}
+
+/**
+ * Union type for HSM crypto configuration.
+ */
+export type HsmCryptoConfig = SimulatorCryptoConfig | Pkcs11CryptoConfig;

--- a/modules/hsm/src/index.ts
+++ b/modules/hsm/src/index.ts
@@ -3,19 +3,44 @@ export type {
   HsmSlotConfig,
   HsmKeyPair,
   HsmSignatureResult,
+  HsmKeyType,
+  HsmNamedCurve,
+  HsmSignatureAlgorithm,
   WrappedKey,
   EncryptedRecord,
   EnvelopeEncryptionResult,
   HsmAuditEntry,
 } from "./domain/entities";
-export type { KeyStore, AuditLog } from "./domain/ports";
+export type {
+  KeyStore,
+  AuditLog,
+  HsmCryptoPort,
+  HsmCryptoConfig,
+  SimulatorCryptoConfig,
+  Pkcs11CryptoConfig,
+  SigningAlgorithm,
+  EcCurve,
+  EdCurve,
+  RsaKeySize,
+  AesKeySize,
+  KeyGenerationResult,
+  WrapKeyResult,
+} from "./domain/ports";
 
 // Application
 export { AsymmetricKeyService } from "./application/asymmetric-key-service";
+export type { KeyGenOptions } from "./application/asymmetric-key-service";
 export { SymmetricKeyService } from "./application/symmetric-key-service";
+export type { SymmetricKeyGenOptions } from "./application/symmetric-key-service";
 export { EnvelopeEncryptionService } from "./application/envelope-encryption-service";
 
-// Infrastructure
+// Infrastructure - Adapters
+export {
+  SimulatorCryptoAdapter,
+  Pkcs11CryptoAdapter,
+} from "./infrastructure/adapters";
+
+// Infrastructure - Persistence & Audit
 export { InMemoryAuditLog } from "./infrastructure/audit-log";
 export { InMemoryKeyStore } from "./infrastructure/key-store";
 export { FileAuditLog } from "./infrastructure/file-audit-log";
@@ -43,22 +68,67 @@ export type {
 //
 // Composes AsymmetricKeyService, SymmetricKeyService, EnvelopeEncryptionService,
 // InMemoryKeyStore, and InMemoryAuditLog behind the same public surface.
+//
+// Supports two modes:
+// - Simulator (default): Uses node:crypto for all key operations
+// - PKCS#11: Uses real hardware HSM via graphene-pk11
+//
+// Use async methods (e.g., generateKeyPairAsync) for PKCS#11 support.
+// Sync methods are backward-compatible but only work with the simulator.
 // ---------------------------------------------------------------------------
 
 import type {
   HsmSlotConfig,
   HsmKeyPair,
   HsmSignatureResult,
+  HsmSignatureAlgorithm,
   WrappedKey,
   EncryptedRecord,
   EnvelopeEncryptionResult,
   HsmAuditEntry,
 } from "./domain/entities";
-import { AsymmetricKeyService } from "./application/asymmetric-key-service";
-import { SymmetricKeyService } from "./application/symmetric-key-service";
+import type { HsmCryptoConfig, HsmCryptoPort } from "./domain/ports";
+import {
+  AsymmetricKeyService,
+  type KeyGenOptions,
+} from "./application/asymmetric-key-service";
+import {
+  SymmetricKeyService,
+  type SymmetricKeyGenOptions,
+} from "./application/symmetric-key-service";
 import { EnvelopeEncryptionService } from "./application/envelope-encryption-service";
 import { InMemoryAuditLog } from "./infrastructure/audit-log";
 import { InMemoryKeyStore } from "./infrastructure/key-store";
+import { SimulatorCryptoAdapter } from "./infrastructure/adapters";
+
+/**
+ * Configuration for HsmClient.
+ *
+ * For simulator mode (default):
+ * ```ts
+ * const hsm = new HsmClient();
+ * hsm.initialize({ slotId: "slot-0", label: "Test HSM" });
+ * ```
+ *
+ * For PKCS#11 mode:
+ * ```ts
+ * const hsm = new HsmClient();
+ * await hsm.initializeAsync({
+ *   slotId: "slot-0",
+ *   label: "Production HSM",
+ *   crypto: {
+ *     type: "pkcs11",
+ *     libraryPath: "/usr/lib/softhsm/libsofthsm2.so",
+ *     slotId: 0,
+ *     pin: "1234",
+ *   },
+ * });
+ * ```
+ */
+export interface HsmClientConfig extends HsmSlotConfig {
+  /** Optional crypto backend configuration. Defaults to simulator. */
+  crypto?: HsmCryptoConfig;
+}
 
 /**
  * Software simulation of a PKCS#11-style HSM.
@@ -67,6 +137,13 @@ import { InMemoryKeyStore } from "./infrastructure/key-store";
  * never returned to callers — only opaque handles or PEM public keys are
  * surfaced externally.  All operations are appended to an immutable audit log.
  *
+ * Supports two modes:
+ * - **Simulator (default)**: Uses node:crypto for key operations. Use sync methods.
+ * - **PKCS#11**: Uses real hardware HSM via graphene-pk11. Use async methods.
+ *
+ * For PKCS#11 mode, use `initializeAsync()` and all `*Async()` methods.
+ * Sync methods are backward-compatible but only work with the simulator.
+ *
  * Ref: PKCS#11 v3.1 — https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.1/pkcs11-curr-v3.1.html
  */
 export class HsmClient {
@@ -74,22 +151,21 @@ export class HsmClient {
   private slotId = "";
   private readonly store = new InMemoryKeyStore();
   private readonly audit = new InMemoryAuditLog();
+  private crypto: HsmCryptoPort | undefined;
   private asymmetric: AsymmetricKeyService | null = null;
   private symmetric: SymmetricKeyService | null = null;
   private envelope: EnvelopeEncryptionService | null = null;
 
+  // ---------------------------------------------------------------------------
+  // Initialization
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Initialize the HSM (synchronous, simulator only).
+   * For PKCS#11 support, use initializeAsync().
+   */
   initialize(config: HsmSlotConfig): void {
-    if (config.slotId.trim().length === 0) {
-      throw new Error("HSM initialize: slotId must not be empty");
-    }
-    if (config.label.trim().length === 0) {
-      throw new Error("HSM initialize: label must not be empty");
-    }
-    if (this.initialized) {
-      throw new Error(
-        `HSM already initialized on slot '${this.slotId}' — create a new HsmClient instance for a different slot`,
-      );
-    }
+    this.validateConfig(config);
     this.slotId = config.slotId;
     this.asymmetric = new AsymmetricKeyService(
       this.store,
@@ -102,34 +178,263 @@ export class HsmClient {
     this.audit.record("initialize", config.slotId, "success", config.label);
   }
 
+  /**
+   * Initialize the HSM asynchronously with optional PKCS#11 support.
+   *
+   * @example
+   * // Simulator mode (default)
+   * await hsm.initializeAsync({ slotId: "slot-0", label: "Test HSM" });
+   *
+   * @example
+   * // PKCS#11 mode with SoftHSM2
+   * await hsm.initializeAsync({
+   *   slotId: "slot-0",
+   *   label: "Production HSM",
+   *   crypto: {
+   *     type: "pkcs11",
+   *     libraryPath: "/usr/lib/softhsm/libsofthsm2.so",
+   *     slotId: 0,
+   *     pin: "1234",
+   *   },
+   * });
+   */
+  async initializeAsync(config: HsmClientConfig): Promise<void> {
+    this.validateConfig(config);
+    this.slotId = config.slotId;
+
+    // Initialize crypto backend
+    if (config.crypto) {
+      if (config.crypto.type === "pkcs11") {
+        // Dynamically import PKCS#11 adapter
+        const { Pkcs11CryptoAdapter } =
+          await import("./infrastructure/adapters");
+        this.crypto = new Pkcs11CryptoAdapter();
+      } else {
+        this.crypto = new SimulatorCryptoAdapter();
+      }
+      await this.crypto.initialize(config.crypto);
+    } else {
+      // Default to simulator
+      this.crypto = new SimulatorCryptoAdapter();
+      await this.crypto.initialize({ type: "simulator" });
+    }
+
+    // Create services with crypto port
+    this.asymmetric = new AsymmetricKeyService(
+      this.store,
+      this.audit,
+      this.slotId,
+      this.crypto,
+    );
+    this.symmetric = new SymmetricKeyService(
+      this.store,
+      this.audit,
+      this.crypto,
+    );
+    this.envelope = new EnvelopeEncryptionService(this.symmetric, this.audit);
+
+    this.initialized = true;
+    this.audit.record(
+      "initialize",
+      config.slotId,
+      "success",
+      `${config.label} (${config.crypto?.type ?? "simulator"})`,
+    );
+  }
+
+  /**
+   * Finalize the HSM and release resources.
+   * Call this when done using PKCS#11 mode to properly close the session.
+   */
+  async finalizeAsync(): Promise<void> {
+    if (this.crypto) {
+      await this.crypto.finalize();
+      this.crypto = undefined;
+    }
+    this.initialized = false;
+    this.audit.record("finalize", this.slotId, "success");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Asymmetric Key Operations (Sync - Backward Compatible)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate EC P-256 key pair (synchronous, simulator only).
+   * For PKCS#11 or other key types, use generateKeyPairAsync().
+   */
   generateKeyPair(keyLabel: string): HsmKeyPair {
     return this.requireAsymmetric().generateKeyPair(keyLabel);
   }
 
+  /**
+   * Sign data (synchronous, simulator only).
+   * For PKCS#11 support, use signAsync().
+   */
   sign(keyLabel: string, data: string): HsmSignatureResult {
     return this.requireAsymmetric().sign(keyLabel, data);
   }
 
+  /**
+   * Verify signature (synchronous, simulator only).
+   * For PKCS#11 support, use verifyAsync().
+   */
   verify(keyLabel: string, data: string, signature: string): boolean {
     return this.requireAsymmetric().verify(keyLabel, data, signature);
   }
 
+  /**
+   * Export public key (synchronous).
+   */
   exportPublicKey(keyLabel: string): string {
     return this.requireAsymmetric().exportPublicKey(keyLabel);
   }
 
+  // ---------------------------------------------------------------------------
+  // Asymmetric Key Operations (Async - PKCS#11 Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate key pair asynchronously.
+   * Supports EC P-256, P-384, Ed25519, RSA-2048, RSA-4096.
+   *
+   * @example
+   * // EC P-256 (default)
+   * const kp = await hsm.generateKeyPairAsync("my-key");
+   *
+   * @example
+   * // Ed25519
+   * const kp = await hsm.generateKeyPairAsync("my-ed-key", {
+   *   keyType: "Ed",
+   *   namedCurve: "Ed25519",
+   * });
+   *
+   * @example
+   * // RSA-4096
+   * const kp = await hsm.generateKeyPairAsync("my-rsa-key", {
+   *   keyType: "RSA",
+   *   rsaBits: 4096,
+   * });
+   */
+  async generateKeyPairAsync(
+    keyLabel: string,
+    options?: KeyGenOptions,
+  ): Promise<HsmKeyPair> {
+    return this.requireAsymmetric().generateKeyPairAsync(keyLabel, options);
+  }
+
+  /**
+   * Sign data asynchronously.
+   * Supports ECDSA-SHA256, ECDSA-SHA384, Ed25519, RSA-PSS-SHA256, RSA-PKCS1-SHA256.
+   */
+  async signAsync(
+    keyLabel: string,
+    data: string,
+    algorithm?: HsmSignatureAlgorithm,
+  ): Promise<HsmSignatureResult> {
+    return this.requireAsymmetric().signAsync(keyLabel, data, algorithm);
+  }
+
+  /**
+   * Verify signature asynchronously.
+   */
+  async verifyAsync(
+    keyLabel: string,
+    data: string,
+    signature: string,
+    algorithm?: HsmSignatureAlgorithm,
+  ): Promise<boolean> {
+    return this.requireAsymmetric().verifyAsync(
+      keyLabel,
+      data,
+      signature,
+      algorithm,
+    );
+  }
+
+  /**
+   * Export public key asynchronously.
+   */
+  async exportPublicKeyAsync(keyLabel: string): Promise<string> {
+    return this.requireAsymmetric().exportPublicKeyAsync(keyLabel);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Symmetric Key Operations (Sync - Backward Compatible)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate AES-256 symmetric key (synchronous, simulator only).
+   * For PKCS#11 or other key sizes, use generateSymmetricKeyAsync().
+   */
   generateSymmetricKey(keyLabel: string): void {
     this.requireSymmetric().generateSymmetricKey(keyLabel);
   }
 
+  /**
+   * Wrap a DEK with a KEK (synchronous, simulator only).
+   * For PKCS#11 support, use wrapKeyAsync().
+   */
   wrapKey(plaintextDek: Buffer, kekLabel: string): WrappedKey {
     return this.requireSymmetric().wrapKey(plaintextDek, kekLabel);
   }
 
+  /**
+   * Unwrap a DEK (synchronous, simulator only).
+   * For PKCS#11 support, use unwrapKeyAsync().
+   */
   unwrapKey(wrapped: WrappedKey): Buffer {
     return this.requireSymmetric().unwrapKey(wrapped);
   }
 
+  // ---------------------------------------------------------------------------
+  // Symmetric Key Operations (Async - PKCS#11 Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Generate symmetric key asynchronously.
+   * Supports AES-128 and AES-256.
+   *
+   * @example
+   * // AES-256 (default)
+   * await hsm.generateSymmetricKeyAsync("my-kek");
+   *
+   * @example
+   * // AES-128
+   * await hsm.generateSymmetricKeyAsync("my-kek-128", { keyBits: 128 });
+   */
+  async generateSymmetricKeyAsync(
+    keyLabel: string,
+    options?: SymmetricKeyGenOptions,
+  ): Promise<void> {
+    return this.requireSymmetric().generateSymmetricKeyAsync(keyLabel, options);
+  }
+
+  /**
+   * Wrap a DEK with a KEK asynchronously.
+   */
+  async wrapKeyAsync(
+    plaintextDek: Buffer,
+    kekLabel: string,
+  ): Promise<WrappedKey> {
+    return this.requireSymmetric().wrapKeyAsync(plaintextDek, kekLabel);
+  }
+
+  /**
+   * Unwrap a DEK asynchronously.
+   */
+  async unwrapKeyAsync(wrapped: WrappedKey): Promise<Buffer> {
+    return this.requireSymmetric().unwrapKeyAsync(wrapped);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Envelope Encryption (Sync - Backward Compatible)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Encrypt with envelope encryption (synchronous, simulator only).
+   * For PKCS#11 support, use encryptWithEnvelopeAsync().
+   */
   encryptWithEnvelope(
     kekLabel: string,
     plaintext: string,
@@ -137,6 +442,10 @@ export class HsmClient {
     return this.requireEnvelope().encrypt(kekLabel, plaintext);
   }
 
+  /**
+   * Decrypt with envelope encryption (synchronous, simulator only).
+   * For PKCS#11 support, use decryptWithEnvelopeAsync().
+   */
   decryptWithEnvelope(
     wrappedDek: WrappedKey,
     encryptedRecord: EncryptedRecord,
@@ -144,8 +453,57 @@ export class HsmClient {
     return this.requireEnvelope().decrypt(wrappedDek, encryptedRecord);
   }
 
+  // ---------------------------------------------------------------------------
+  // Envelope Encryption (Async - PKCS#11 Support)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Encrypt with envelope encryption asynchronously.
+   */
+  async encryptWithEnvelopeAsync(
+    kekLabel: string,
+    plaintext: string,
+  ): Promise<EnvelopeEncryptionResult> {
+    return this.requireEnvelope().encryptAsync(kekLabel, plaintext);
+  }
+
+  /**
+   * Decrypt with envelope encryption asynchronously.
+   */
+  async decryptWithEnvelopeAsync(
+    wrappedDek: WrappedKey,
+    encryptedRecord: EncryptedRecord,
+  ): Promise<string> {
+    return this.requireEnvelope().decryptAsync(wrappedDek, encryptedRecord);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audit
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Get the audit log entries.
+   */
   getAuditLog(): readonly HsmAuditEntry[] {
     return this.audit.entries();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private validateConfig(config: HsmSlotConfig): void {
+    if (config.slotId.trim().length === 0) {
+      throw new Error("HSM initialize: slotId must not be empty");
+    }
+    if (config.label.trim().length === 0) {
+      throw new Error("HSM initialize: label must not be empty");
+    }
+    if (this.initialized) {
+      throw new Error(
+        `HSM already initialized on slot '${this.slotId}' — create a new HsmClient instance for a different slot`,
+      );
+    }
   }
 
   private requireAsymmetric(): AsymmetricKeyService {

--- a/modules/hsm/src/index.ts
+++ b/modules/hsm/src/index.ts
@@ -119,8 +119,8 @@ import { SimulatorCryptoAdapter } from "./infrastructure/adapters";
  *   crypto: {
  *     type: "pkcs11",
  *     libraryPath: "/usr/lib/softhsm/libsofthsm2.so",
- *     slotId: 0,
- *     pin: "1234",
+ *     slotIndex: 0,
+ *     userPin: "1234",
  *   },
  * });
  * ```

--- a/modules/hsm/src/infrastructure/adapters/index.ts
+++ b/modules/hsm/src/infrastructure/adapters/index.ts
@@ -1,0 +1,10 @@
+/**
+ * HSM Crypto Adapters
+ *
+ * Provides implementations of HsmCryptoPort for different backends:
+ * - SimulatorCryptoAdapter: Software implementation using node:crypto
+ * - Pkcs11CryptoAdapter: Hardware HSM implementation using PKCS#11
+ */
+
+export { SimulatorCryptoAdapter } from "./simulator-crypto-adapter";
+export { Pkcs11CryptoAdapter } from "./pkcs11-crypto-adapter";

--- a/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
@@ -609,16 +609,22 @@ export class Pkcs11CryptoAdapter implements HsmCryptoPort {
     publicKey: any,
     privateKeyHandle: Buffer,
   ): boolean {
-    // In PKCS#11, matching public/private keys typically share
-    // the same CKA_ID attribute. This is vendor-dependent.
+    // In PKCS#11, matching public/private keys should share
+    // the same CKA_ID attribute. Fail closed if we can't verify.
     try {
       const publicKeyId = publicKey.getAttribute({ id: null }).id;
       const privateKey = this.findKeyByHandle(privateKeyHandle);
       const privateKeyId = privateKey.getAttribute({ id: null }).id;
-      return publicKeyId && privateKeyId && publicKeyId.equals(privateKeyId);
+
+      // Require both IDs to be valid buffers
+      if (!Buffer.isBuffer(publicKeyId) || !Buffer.isBuffer(privateKeyId)) {
+        return false;
+      }
+
+      return publicKeyId.equals(privateKeyId);
     } catch {
-      // Fallback: just use any public key with matching type
-      return true;
+      // Fail closed: if we can't verify the match, reject it
+      return false;
     }
   }
 
@@ -643,19 +649,22 @@ export class Pkcs11CryptoAdapter implements HsmCryptoPort {
   private constructEcSpki(ecParams: Buffer, ecPoint: Buffer): Buffer {
     // Simplified SPKI construction for EC keys
     // In production, use a proper ASN.1 library
-    const algorithm = Buffer.from([
-      0x30,
-      0x13, // SEQUENCE
-      0x06,
-      0x07,
-      0x2a,
-      0x86,
-      0x48,
-      0xce,
-      0x3d,
-      0x02,
-      0x01, // OID: ecPublicKey
-      ...ecParams, // EC parameters (curve OID)
+
+    // ecPublicKey OID: 1.2.840.10045.2.1
+    const ecPublicKeyOid = Buffer.from([
+      0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01,
+    ]);
+
+    // AlgorithmIdentifier SEQUENCE contains: ecPublicKey OID + curve params
+    const algorithmContent = Buffer.concat([ecPublicKeyOid, ecParams]);
+    const algorithmSeqLen = algorithmContent.length;
+
+    // Build AlgorithmIdentifier SEQUENCE with computed length
+    const algorithm = Buffer.concat([
+      algorithmSeqLen < 128
+        ? Buffer.from([0x30, algorithmSeqLen])
+        : Buffer.from([0x30, 0x81, algorithmSeqLen]),
+      algorithmContent,
     ]);
 
     const bitString = Buffer.concat([

--- a/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
@@ -32,7 +32,6 @@ import type {
   HsmCryptoConfig,
   HsmCryptoPort,
   KeyGenerationResult,
-  Pkcs11CryptoConfig,
   RsaKeySize,
   SigningAlgorithm,
   WrapKeyResult,
@@ -61,7 +60,6 @@ export class Pkcs11CryptoAdapter implements HsmCryptoPort {
   private mod: GrapheneModule | null = null;
   private slot: GrapheneSlot | null = null;
   private session: GrapheneSession | null = null;
-  private config: Pkcs11CryptoConfig | null = null;
   private initialized = false;
 
   // Map of key handles to PKCS#11 object handles
@@ -76,8 +74,6 @@ export class Pkcs11CryptoAdapter implements HsmCryptoPort {
     if (config.type !== "pkcs11") {
       throw new Error("Pkcs11CryptoAdapter requires type: 'pkcs11'");
     }
-
-    this.config = config;
 
     // Lazy load graphene-pk11
     try {

--- a/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts
@@ -1,0 +1,680 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * PKCS#11 Crypto Adapter
+ *
+ * Real hardware HSM implementation of HsmCryptoPort using graphene-pk11.
+ * Supports industry-standard PKCS#11 v2.40+ compliant HSMs:
+ * - Thales nShield
+ * - Utimaco SecurityServer
+ * - SafeNet Luna
+ * - AWS CloudHSM
+ * - SoftHSM2 (for testing)
+ *
+ * Ref: PKCS#11 v3.1 — https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.1/pkcs11-curr-v3.1.html
+ *
+ * SECURITY: PINs should NEVER be hardcoded. Use environment variables or
+ * secret managers (AWS Secrets Manager, HashiCorp Vault, etc.)
+ */
+
+import type {
+  AesKeySize,
+  EcCurve,
+  EdCurve,
+  HsmCryptoConfig,
+  HsmCryptoPort,
+  KeyGenerationResult,
+  Pkcs11CryptoConfig,
+  RsaKeySize,
+  SigningAlgorithm,
+  WrapKeyResult,
+} from "../../domain/ports";
+
+// Type definitions for graphene-pk11 (loaded dynamically)
+type GrapheneModule = any;
+type GrapheneSlot = any;
+type GrapheneSession = any;
+
+/**
+ * Real PKCS#11 hardware HSM adapter using graphene-pk11.
+ *
+ * Supports:
+ * - EC P-256, P-384 key generation (CKM_EC_KEY_PAIR_GEN)
+ * - Ed25519 key generation (CKM_EC_EDWARDS_KEY_PAIR_GEN)
+ * - RSA-2048, RSA-4096 key generation (CKM_RSA_PKCS_KEY_PAIR_GEN)
+ * - AES-128, AES-256 key generation (CKM_AES_KEY_GEN)
+ * - ECDSA signing (CKM_ECDSA_SHA256, CKM_ECDSA_SHA384)
+ * - EdDSA signing (CKM_EDDSA)
+ * - RSA signing (CKM_RSA_PKCS_PSS, CKM_RSA_PKCS)
+ * - AES-GCM key wrapping (CKM_AES_GCM)
+ */
+export class Pkcs11CryptoAdapter implements HsmCryptoPort {
+  private graphene: GrapheneModule | null = null;
+  private mod: GrapheneModule | null = null;
+  private slot: GrapheneSlot | null = null;
+  private session: GrapheneSession | null = null;
+  private config: Pkcs11CryptoConfig | null = null;
+  private initialized = false;
+
+  // Map of key handles to PKCS#11 object handles
+  private keyHandleMap = new Map<string, Buffer>();
+  private handleCounter = 0;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  async initialize(config: HsmCryptoConfig): Promise<void> {
+    if (config.type !== "pkcs11") {
+      throw new Error("Pkcs11CryptoAdapter requires type: 'pkcs11'");
+    }
+
+    this.config = config;
+
+    // Lazy load graphene-pk11
+    try {
+      this.graphene = await import("graphene-pk11");
+    } catch {
+      throw new Error(
+        "graphene-pk11 is required for PKCS#11 support. " +
+          "Install it with: npm install graphene-pk11",
+      );
+    }
+
+    try {
+      // Load PKCS#11 library
+      this.mod = this.graphene.Module.load(config.libraryPath);
+      this.mod.initialize();
+
+      // Find slot
+      const slots = this.mod.getSlots(true); // true = token present
+      if (config.tokenLabel) {
+        this.slot = this.findSlotByLabel(slots, config.tokenLabel);
+      } else {
+        const slotIndex = config.slotIndex ?? 0;
+        this.slot = slots.items(slotIndex);
+      }
+
+      if (!this.slot) {
+        throw new Error(
+          config.tokenLabel
+            ? `PKCS#11 token not found: ${config.tokenLabel}`
+            : `PKCS#11 slot not found at index ${config.slotIndex ?? 0}`,
+        );
+      }
+
+      // Open session
+      const SessionFlag = this.graphene.SessionFlag;
+      const sessionFlags = config.readOnly
+        ? SessionFlag.RO_SESSION | SessionFlag.SERIAL_SESSION
+        : SessionFlag.RW_SESSION | SessionFlag.SERIAL_SESSION;
+
+      this.session = this.slot.open(sessionFlags);
+
+      // Login
+      const UserType = this.graphene.UserType;
+      this.session.login(config.userPin, UserType.USER);
+
+      this.initialized = true;
+    } catch (error) {
+      // Cleanup on failure
+      await this.cleanup();
+      throw error;
+    }
+  }
+
+  async finalize(): Promise<void> {
+    await this.cleanup();
+    this.keyHandleMap.clear();
+    this.initialized = false;
+  }
+
+  private async cleanup(): Promise<void> {
+    try {
+      if (this.session) {
+        try {
+          this.session.logout();
+        } catch {
+          // Ignore logout errors
+        }
+        try {
+          this.session.close();
+        } catch {
+          // Ignore close errors
+        }
+        this.session = null;
+      }
+
+      if (this.mod) {
+        try {
+          this.mod.finalize();
+        } catch {
+          // Ignore finalize errors
+        }
+        this.mod = null;
+      }
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Asymmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  async generateEcKeyPair(curve: EcCurve): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    const { KeyGenMechanism, KeyType, NamedCurve, ObjectClass } =
+      this.graphene!;
+
+    // Map curve name to OID
+    const curveOid =
+      curve === "P-256"
+        ? NamedCurve.getByName("secp256r1")
+        : NamedCurve.getByName("secp384r1");
+
+    const keyPair = this.session!.generateKeyPair(
+      KeyGenMechanism.EC,
+      {
+        keyType: KeyType.EC,
+        paramsEC: curveOid.value,
+        token: true,
+        private: true,
+        sensitive: true,
+        extractable: false,
+        sign: true,
+      },
+      {
+        keyType: KeyType.EC,
+        token: true,
+        private: false,
+        verify: true,
+      },
+    );
+
+    const handle = `pkcs11:ec:${++this.handleCounter}`;
+    this.keyHandleMap.set(handle, keyPair.privateKey.handle);
+
+    // Export public key
+    const publicKeyDer = this.exportPublicKeyDer(
+      keyPair.publicKey,
+      ObjectClass.PUBLIC_KEY,
+    );
+    const publicKeyPem = this.derToPem(publicKeyDer, "PUBLIC KEY");
+
+    return { handle, publicKeyPem };
+  }
+
+  async generateEdKeyPair(curve: EdCurve): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    if (curve !== "Ed25519") {
+      throw new Error(`Unsupported Edwards curve: ${curve}`);
+    }
+
+    const { KeyGenMechanism, KeyType, ObjectClass } = this.graphene!;
+
+    // Ed25519 OID: 1.3.101.112
+    const ed25519Oid = Buffer.from([0x06, 0x03, 0x2b, 0x65, 0x70]);
+
+    const keyPair = this.session!.generateKeyPair(
+      KeyGenMechanism.EC_EDWARDS,
+      {
+        keyType: KeyType.EC_EDWARDS,
+        paramsECDH: ed25519Oid,
+        token: true,
+        private: true,
+        sensitive: true,
+        extractable: false,
+        sign: true,
+      },
+      {
+        keyType: KeyType.EC_EDWARDS,
+        token: true,
+        private: false,
+        verify: true,
+      },
+    );
+
+    const handle = `pkcs11:ed:${++this.handleCounter}`;
+    this.keyHandleMap.set(handle, keyPair.privateKey.handle);
+
+    // Export public key
+    const publicKeyDer = this.exportPublicKeyDer(
+      keyPair.publicKey,
+      ObjectClass.PUBLIC_KEY,
+    );
+    const publicKeyPem = this.derToPem(publicKeyDer, "PUBLIC KEY");
+
+    return { handle, publicKeyPem };
+  }
+
+  async generateRsaKeyPair(bits: RsaKeySize): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    const { KeyGenMechanism, KeyType, ObjectClass } = this.graphene!;
+
+    const keyPair = this.session!.generateKeyPair(
+      KeyGenMechanism.RSA,
+      {
+        keyType: KeyType.RSA,
+        modulusBits: bits,
+        publicExponent: Buffer.from([0x01, 0x00, 0x01]), // 65537
+        token: true,
+        private: true,
+        sensitive: true,
+        extractable: false,
+        sign: true,
+      },
+      {
+        keyType: KeyType.RSA,
+        token: true,
+        private: false,
+        verify: true,
+      },
+    );
+
+    const handle = `pkcs11:rsa:${++this.handleCounter}`;
+    this.keyHandleMap.set(handle, keyPair.privateKey.handle);
+
+    // Export public key
+    const publicKeyDer = this.exportPublicKeyDer(
+      keyPair.publicKey,
+      ObjectClass.PUBLIC_KEY,
+    );
+    const publicKeyPem = this.derToPem(publicKeyDer, "PUBLIC KEY");
+
+    return { handle, publicKeyPem };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Symmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  async generateAesKey(bits: AesKeySize): Promise<string> {
+    this.assertInitialized();
+
+    const { KeyGenMechanism, KeyType } = this.graphene!;
+
+    const key = this.session!.generateKey(KeyGenMechanism.AES, {
+      keyType: KeyType.AES,
+      valueLen: bits / 8,
+      token: true,
+      private: true,
+      sensitive: true,
+      extractable: false,
+      wrap: true,
+      unwrap: true,
+      encrypt: true,
+      decrypt: true,
+    });
+
+    const handle = `pkcs11:aes:${++this.handleCounter}`;
+    this.keyHandleMap.set(handle, key.handle);
+
+    return handle;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Signing Operations
+  // ---------------------------------------------------------------------------
+
+  async sign(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+  ): Promise<Buffer> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.requirePkcs11Handle(keyHandle);
+    const privateKey = this.findKeyByHandle(pkcs11Handle);
+
+    const { MechanismEnum } = this.graphene!;
+
+    let mechanism: number;
+    switch (algorithm) {
+      case "ecdsa-sha256":
+        mechanism = MechanismEnum.ECDSA_SHA256;
+        break;
+      case "ecdsa-sha384":
+        mechanism = MechanismEnum.ECDSA_SHA384;
+        break;
+      case "ed25519":
+        mechanism = MechanismEnum.EDDSA;
+        break;
+      case "rsa-pss-sha256":
+        mechanism = MechanismEnum.SHA256_RSA_PKCS_PSS;
+        break;
+      case "rsa-pkcs1-sha256":
+        mechanism = MechanismEnum.SHA256_RSA_PKCS;
+        break;
+      default:
+        throw new Error(`Unsupported signing algorithm: ${algorithm}`);
+    }
+
+    const sign = this.session!.createSign(mechanism, privateKey);
+    sign.update(data);
+    return sign.final();
+  }
+
+  async verify(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+    signature: Buffer,
+  ): Promise<boolean> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.requirePkcs11Handle(keyHandle);
+
+    // Find the corresponding public key
+    const { ObjectClass } = this.graphene!;
+    const objects = this.session!.find({ class: ObjectClass.PUBLIC_KEY });
+    let publicKey = null;
+
+    // Try to find a matching public key
+    // In PKCS#11, public/private keys are separate objects
+    // We need to find the public key that matches the private key
+    for (const obj of objects) {
+      if (this.isMatchingPublicKey(obj, pkcs11Handle)) {
+        publicKey = obj;
+        break;
+      }
+    }
+
+    if (!publicKey) {
+      throw new Error(`Public key not found for handle: ${keyHandle}`);
+    }
+
+    const { MechanismEnum } = this.graphene!;
+
+    let mechanism: number;
+    switch (algorithm) {
+      case "ecdsa-sha256":
+        mechanism = MechanismEnum.ECDSA_SHA256;
+        break;
+      case "ecdsa-sha384":
+        mechanism = MechanismEnum.ECDSA_SHA384;
+        break;
+      case "ed25519":
+        mechanism = MechanismEnum.EDDSA;
+        break;
+      case "rsa-pss-sha256":
+        mechanism = MechanismEnum.SHA256_RSA_PKCS_PSS;
+        break;
+      case "rsa-pkcs1-sha256":
+        mechanism = MechanismEnum.SHA256_RSA_PKCS;
+        break;
+      default:
+        throw new Error(`Unsupported verification algorithm: ${algorithm}`);
+    }
+
+    try {
+      const verify = this.session!.createVerify(mechanism, publicKey);
+      verify.update(data);
+      verify.final(signature);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Export
+  // ---------------------------------------------------------------------------
+
+  async exportPublicKey(keyHandle: string): Promise<string> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.requirePkcs11Handle(keyHandle);
+
+    // Find the corresponding public key
+    const { ObjectClass } = this.graphene!;
+    const objects = this.session!.find({ class: ObjectClass.PUBLIC_KEY });
+
+    for (const obj of objects) {
+      if (this.isMatchingPublicKey(obj, pkcs11Handle)) {
+        const der = this.exportPublicKeyDer(obj, ObjectClass.PUBLIC_KEY);
+        return this.derToPem(der, "PUBLIC KEY");
+      }
+    }
+
+    throw new Error(`Public key not found for handle: ${keyHandle}`);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Wrapping (Envelope Encryption)
+  // ---------------------------------------------------------------------------
+
+  async wrapKey(dekBytes: Buffer, kekHandle: string): Promise<WrapKeyResult> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.requirePkcs11Handle(kekHandle);
+    const kek = this.findKeyByHandle(pkcs11Handle);
+
+    const { MechanismEnum } = this.graphene!;
+
+    // Generate random IV
+    const iv = Buffer.alloc(12);
+    // Use PKCS#11 random generation
+    this.session!.generateRandom(iv);
+
+    // AES-GCM parameters
+    const gcmParams = {
+      iv,
+      ivBits: 96,
+      aad: Buffer.alloc(0),
+      tagBits: 128,
+    };
+
+    const cipher = this.session!.createCipher(
+      { mechanism: MechanismEnum.AES_GCM, parameter: gcmParams },
+      kek,
+    );
+
+    cipher.update(dekBytes);
+    const result = cipher.final();
+
+    // In AES-GCM, the auth tag is appended to the ciphertext
+    const ciphertextWithTag = result;
+    const wrappedDek = ciphertextWithTag.slice(0, -16);
+    const authTag = ciphertextWithTag.slice(-16);
+
+    return { wrappedDek, iv, authTag };
+  }
+
+  async unwrapKey(
+    wrappedDek: Buffer,
+    iv: Buffer,
+    authTag: Buffer,
+    kekHandle: string,
+  ): Promise<Buffer> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.requirePkcs11Handle(kekHandle);
+    const kek = this.findKeyByHandle(pkcs11Handle);
+
+    const { MechanismEnum } = this.graphene!;
+
+    // Reconstruct ciphertext with auth tag
+    const ciphertextWithTag = Buffer.concat([wrappedDek, authTag]);
+
+    // AES-GCM parameters
+    const gcmParams = {
+      iv,
+      ivBits: 96,
+      aad: Buffer.alloc(0),
+      tagBits: 128,
+    };
+
+    try {
+      const decipher = this.session!.createDecipher(
+        { mechanism: MechanismEnum.AES_GCM, parameter: gcmParams },
+        kek,
+      );
+
+      decipher.update(ciphertextWithTag);
+      return decipher.final();
+    } catch {
+      throw new Error("Key unwrap failed: GCM authentication failed");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Management
+  // ---------------------------------------------------------------------------
+
+  async destroyKey(handle: string): Promise<void> {
+    this.assertInitialized();
+
+    const pkcs11Handle = this.keyHandleMap.get(handle);
+    if (!pkcs11Handle) {
+      return; // Key doesn't exist, nothing to destroy
+    }
+
+    try {
+      const key = this.findKeyByHandle(pkcs11Handle);
+      key.destroy();
+      this.keyHandleMap.delete(handle);
+    } catch {
+      // Key may already be destroyed
+      this.keyHandleMap.delete(handle);
+    }
+  }
+
+  async hasKey(handle: string): Promise<boolean> {
+    return this.keyHandleMap.has(handle);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private assertInitialized(): void {
+    if (!this.initialized || !this.session) {
+      throw new Error("Pkcs11CryptoAdapter not initialized");
+    }
+  }
+
+  private requirePkcs11Handle(handle: string): Buffer {
+    const pkcs11Handle = this.keyHandleMap.get(handle);
+    if (!pkcs11Handle) {
+      throw new Error(`Key not found: ${handle}`);
+    }
+    return pkcs11Handle;
+  }
+
+  private findSlotByLabel(slots: any, label: string): GrapheneSlot | null {
+    for (let i = 0; i < slots.length; i++) {
+      const slot = slots.items(i);
+      if (slot.token && slot.token.label.trim() === label) {
+        return slot;
+      }
+    }
+    return null;
+  }
+
+  private findKeyByHandle(handle: Buffer): any {
+    const { ObjectClass } = this.graphene!;
+
+    // Try to find as private key first
+    const privateKeys = this.session!.find({ class: ObjectClass.PRIVATE_KEY });
+    for (const key of privateKeys) {
+      if (key.handle.equals(handle)) {
+        return key;
+      }
+    }
+
+    // Try to find as secret key
+    const secretKeys = this.session!.find({ class: ObjectClass.SECRET_KEY });
+    for (const key of secretKeys) {
+      if (key.handle.equals(handle)) {
+        return key;
+      }
+    }
+
+    throw new Error("Key not found on HSM");
+  }
+
+  private isMatchingPublicKey(
+    publicKey: any,
+    privateKeyHandle: Buffer,
+  ): boolean {
+    // In PKCS#11, matching public/private keys typically share
+    // the same CKA_ID attribute. This is vendor-dependent.
+    try {
+      const publicKeyId = publicKey.getAttribute({ id: null }).id;
+      const privateKey = this.findKeyByHandle(privateKeyHandle);
+      const privateKeyId = privateKey.getAttribute({ id: null }).id;
+      return publicKeyId && privateKeyId && publicKeyId.equals(privateKeyId);
+    } catch {
+      // Fallback: just use any public key with matching type
+      return true;
+    }
+  }
+
+  private exportPublicKeyDer(publicKey: any, _objectClass: any): Buffer {
+    // Get the public key value (DER-encoded SPKI)
+    try {
+      // For EC keys, we need to construct the SPKI from the EC point
+      const attrs = publicKey.getAttribute({ value: null, ecParams: null });
+
+      if (attrs.ecParams) {
+        // EC key - construct SPKI
+        return this.constructEcSpki(attrs.ecParams, attrs.value);
+      } else {
+        // RSA key - the value should already be SPKI
+        return attrs.value;
+      }
+    } catch {
+      throw new Error("Failed to export public key");
+    }
+  }
+
+  private constructEcSpki(ecParams: Buffer, ecPoint: Buffer): Buffer {
+    // Simplified SPKI construction for EC keys
+    // In production, use a proper ASN.1 library
+    const algorithm = Buffer.from([
+      0x30,
+      0x13, // SEQUENCE
+      0x06,
+      0x07,
+      0x2a,
+      0x86,
+      0x48,
+      0xce,
+      0x3d,
+      0x02,
+      0x01, // OID: ecPublicKey
+      ...ecParams, // EC parameters (curve OID)
+    ]);
+
+    const bitString = Buffer.concat([
+      Buffer.from([0x03, ecPoint.length + 1, 0x00]), // BIT STRING header
+      ecPoint,
+    ]);
+
+    const totalLength = algorithm.length + bitString.length;
+    const header =
+      totalLength < 128
+        ? Buffer.from([0x30, totalLength])
+        : Buffer.from([0x30, 0x81, totalLength]);
+
+    return Buffer.concat([header, algorithm, bitString]);
+  }
+
+  private derToPem(der: Buffer, label: string): string {
+    const base64 = der.toString("base64");
+    const lines = base64.match(/.{1,64}/g) || [];
+    return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+  }
+}

--- a/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  constants,
   createCipheriv,
   createDecipheriv,
   createPrivateKey,
@@ -248,7 +249,7 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
         signer.end();
         return signer.sign({
           key: privateKey,
-          padding: 6, // RSA_PKCS1_PSS_PADDING
+          padding: constants.RSA_PKCS1_PSS_PADDING,
           saltLength: 32,
         });
       }
@@ -260,7 +261,7 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
         signer.end();
         return signer.sign({
           key: privateKey,
-          padding: 1, // RSA_PKCS1_PADDING
+          padding: constants.RSA_PKCS1_PADDING,
         });
       }
 
@@ -316,7 +317,7 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
         return verifier.verify(
           {
             key: publicKey,
-            padding: 6, // RSA_PKCS1_PSS_PADDING
+            padding: constants.RSA_PKCS1_PSS_PADDING,
             saltLength: 32,
           },
           signature,
@@ -331,7 +332,7 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
         return verifier.verify(
           {
             key: publicKey,
-            padding: 1, // RSA_PKCS1_PADDING
+            padding: constants.RSA_PKCS1_PADDING,
           },
           signature,
         );

--- a/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
@@ -1,0 +1,472 @@
+/* eslint-disable @typescript-eslint/require-await */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/**
+ * Simulator Crypto Adapter
+ *
+ * Software implementation of HsmCryptoPort using node:crypto.
+ * Provides full key suite support: EC P-256/P-384, Ed25519, RSA-2048/4096, AES-128/256.
+ *
+ * This adapter is used for development and testing. For production,
+ * use Pkcs11CryptoAdapter with real hardware HSM.
+ *
+ * SECURITY: Private keys are stored in memory. In production, keys should
+ * never leave hardware-protected storage.
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  createPrivateKey,
+  createPublicKey,
+  createSign,
+  createVerify,
+  generateKeyPairSync,
+  randomBytes,
+  sign,
+  verify,
+} from "node:crypto";
+
+import type {
+  AesKeySize,
+  EcCurve,
+  EdCurve,
+  HsmCryptoConfig,
+  HsmCryptoPort,
+  KeyGenerationResult,
+  RsaKeySize,
+  SigningAlgorithm,
+  WrapKeyResult,
+} from "../../domain/ports";
+
+/**
+ * Internal key storage for simulator.
+ */
+interface SimulatorKeyEntry {
+  type: "ec" | "ed" | "rsa" | "aes";
+  privateKeyPem?: string;
+  publicKeyPem?: string;
+  keyBytes?: Buffer;
+  curve?: EcCurve | EdCurve;
+  rsaBits?: RsaKeySize;
+  aesBits?: AesKeySize;
+}
+
+/**
+ * Software HSM simulator using node:crypto.
+ *
+ * Supports:
+ * - EC P-256, P-384 key generation and ECDSA signing
+ * - Ed25519 key generation and EdDSA signing
+ * - RSA-2048, RSA-4096 key generation and RSA-PSS/PKCS1 signing
+ * - AES-128, AES-256 key generation and GCM wrapping
+ */
+export class SimulatorCryptoAdapter implements HsmCryptoPort {
+  private keys = new Map<string, SimulatorKeyEntry>();
+  private handleCounter = 0;
+  private initialized = false;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  async initialize(config: HsmCryptoConfig): Promise<void> {
+    if (config.type !== "simulator") {
+      throw new Error("SimulatorCryptoAdapter requires type: 'simulator'");
+    }
+    this.initialized = true;
+  }
+
+  async finalize(): Promise<void> {
+    // Zeroize all key material
+    for (const [, entry] of this.keys) {
+      if (entry.keyBytes) {
+        entry.keyBytes.fill(0);
+      }
+      // Note: We can't truly zeroize PEM strings, but we clear references
+      if (entry.privateKeyPem) {
+        entry.privateKeyPem = "";
+      }
+    }
+    this.keys.clear();
+    this.initialized = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Asymmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  async generateEcKeyPair(curve: EcCurve): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    const { privateKey, publicKey } = generateKeyPairSync("ec", {
+      namedCurve: curve,
+    });
+
+    const handle = `sim:ec:${++this.handleCounter}`;
+    const publicKeyPem = publicKey.export({
+      type: "spki",
+      format: "pem",
+    }) as string;
+    const privateKeyPem = privateKey.export({
+      type: "pkcs8",
+      format: "pem",
+    }) as string;
+
+    this.keys.set(handle, {
+      type: "ec",
+      privateKeyPem,
+      publicKeyPem,
+      curve,
+    });
+
+    return { handle, publicKeyPem };
+  }
+
+  async generateEdKeyPair(curve: EdCurve): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    if (curve !== "Ed25519") {
+      throw new Error(`Unsupported Edwards curve: ${curve}`);
+    }
+
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+
+    const handle = `sim:ed:${++this.handleCounter}`;
+    const publicKeyPem = publicKey.export({
+      type: "spki",
+      format: "pem",
+    }) as string;
+    const privateKeyPem = privateKey.export({
+      type: "pkcs8",
+      format: "pem",
+    }) as string;
+
+    this.keys.set(handle, {
+      type: "ed",
+      privateKeyPem,
+      publicKeyPem,
+      curve,
+    });
+
+    return { handle, publicKeyPem };
+  }
+
+  async generateRsaKeyPair(bits: RsaKeySize): Promise<KeyGenerationResult> {
+    this.assertInitialized();
+
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: bits,
+      publicExponent: 65537,
+    });
+
+    const handle = `sim:rsa:${++this.handleCounter}`;
+    const publicKeyPem = publicKey.export({
+      type: "spki",
+      format: "pem",
+    }) as string;
+    const privateKeyPem = privateKey.export({
+      type: "pkcs8",
+      format: "pem",
+    }) as string;
+
+    this.keys.set(handle, {
+      type: "rsa",
+      privateKeyPem,
+      publicKeyPem,
+      rsaBits: bits,
+    });
+
+    return { handle, publicKeyPem };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Symmetric Key Generation
+  // ---------------------------------------------------------------------------
+
+  async generateAesKey(bits: AesKeySize): Promise<string> {
+    this.assertInitialized();
+
+    const keyBytes = randomBytes(bits / 8);
+    const handle = `sim:aes:${++this.handleCounter}`;
+
+    this.keys.set(handle, {
+      type: "aes",
+      keyBytes,
+      aesBits: bits,
+    });
+
+    return handle;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Signing Operations
+  // ---------------------------------------------------------------------------
+
+  async sign(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+  ): Promise<Buffer> {
+    this.assertInitialized();
+
+    const entry = this.requireKey(keyHandle);
+
+    if (!entry.privateKeyPem) {
+      throw new Error(`Key ${keyHandle} has no private key material`);
+    }
+
+    const privateKey = createPrivateKey(entry.privateKeyPem);
+
+    switch (algorithm) {
+      case "ecdsa-sha256": {
+        this.assertKeyType(entry, "ec", keyHandle);
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer.sign(privateKey);
+      }
+
+      case "ecdsa-sha384": {
+        this.assertKeyType(entry, "ec", keyHandle);
+        const signer = createSign("SHA384");
+        signer.update(data);
+        signer.end();
+        return signer.sign(privateKey);
+      }
+
+      case "ed25519": {
+        this.assertKeyType(entry, "ed", keyHandle);
+        // Ed25519 uses crypto.sign() directly, not createSign()
+        return sign(null, data, privateKey);
+      }
+
+      case "rsa-pss-sha256": {
+        this.assertKeyType(entry, "rsa", keyHandle);
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer.sign({
+          key: privateKey,
+          padding: 6, // RSA_PKCS1_PSS_PADDING
+          saltLength: 32,
+        });
+      }
+
+      case "rsa-pkcs1-sha256": {
+        this.assertKeyType(entry, "rsa", keyHandle);
+        const signer = createSign("SHA256");
+        signer.update(data);
+        signer.end();
+        return signer.sign({
+          key: privateKey,
+          padding: 1, // RSA_PKCS1_PADDING
+        });
+      }
+
+      default:
+        throw new Error(`Unsupported signing algorithm: ${algorithm}`);
+    }
+  }
+
+  async verify(
+    keyHandle: string,
+    algorithm: SigningAlgorithm,
+    data: Buffer,
+    signature: Buffer,
+  ): Promise<boolean> {
+    this.assertInitialized();
+
+    const entry = this.requireKey(keyHandle);
+
+    if (!entry.publicKeyPem) {
+      throw new Error(`Key ${keyHandle} has no public key material`);
+    }
+
+    const publicKey = createPublicKey(entry.publicKeyPem);
+
+    switch (algorithm) {
+      case "ecdsa-sha256": {
+        this.assertKeyType(entry, "ec", keyHandle);
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(publicKey, signature);
+      }
+
+      case "ecdsa-sha384": {
+        this.assertKeyType(entry, "ec", keyHandle);
+        const verifier = createVerify("SHA384");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(publicKey, signature);
+      }
+
+      case "ed25519": {
+        this.assertKeyType(entry, "ed", keyHandle);
+        // Ed25519 uses crypto.verify() directly, not createVerify()
+        return verify(null, data, publicKey, signature);
+      }
+
+      case "rsa-pss-sha256": {
+        this.assertKeyType(entry, "rsa", keyHandle);
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(
+          {
+            key: publicKey,
+            padding: 6, // RSA_PKCS1_PSS_PADDING
+            saltLength: 32,
+          },
+          signature,
+        );
+      }
+
+      case "rsa-pkcs1-sha256": {
+        this.assertKeyType(entry, "rsa", keyHandle);
+        const verifier = createVerify("SHA256");
+        verifier.update(data);
+        verifier.end();
+        return verifier.verify(
+          {
+            key: publicKey,
+            padding: 1, // RSA_PKCS1_PADDING
+          },
+          signature,
+        );
+      }
+
+      default:
+        throw new Error(`Unsupported verification algorithm: ${algorithm}`);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Export
+  // ---------------------------------------------------------------------------
+
+  async exportPublicKey(keyHandle: string): Promise<string> {
+    this.assertInitialized();
+
+    const entry = this.requireKey(keyHandle);
+
+    if (!entry.publicKeyPem) {
+      throw new Error(`Key ${keyHandle} has no public key`);
+    }
+
+    return entry.publicKeyPem;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Wrapping (Envelope Encryption)
+  // ---------------------------------------------------------------------------
+
+  async wrapKey(dekBytes: Buffer, kekHandle: string): Promise<WrapKeyResult> {
+    this.assertInitialized();
+
+    const entry = this.requireKey(kekHandle);
+    this.assertKeyType(entry, "aes", kekHandle);
+
+    if (!entry.keyBytes) {
+      throw new Error(`Key ${kekHandle} has no key material`);
+    }
+
+    const kekBuffer = Buffer.from(entry.keyBytes);
+    const iv = randomBytes(12);
+
+    try {
+      const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+      const wrappedDek = Buffer.concat([
+        cipher.update(dekBytes),
+        cipher.final(),
+      ]);
+      const authTag = cipher.getAuthTag();
+
+      return { wrappedDek, iv, authTag };
+    } finally {
+      // Zeroize the ephemeral KEK copy
+      kekBuffer.fill(0);
+    }
+  }
+
+  async unwrapKey(
+    wrappedDek: Buffer,
+    iv: Buffer,
+    authTag: Buffer,
+    kekHandle: string,
+  ): Promise<Buffer> {
+    this.assertInitialized();
+
+    const entry = this.requireKey(kekHandle);
+    this.assertKeyType(entry, "aes", kekHandle);
+
+    if (!entry.keyBytes) {
+      throw new Error(`Key ${kekHandle} has no key material`);
+    }
+
+    const kekBuffer = Buffer.from(entry.keyBytes);
+
+    try {
+      const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+      decipher.setAuthTag(authTag);
+      return Buffer.concat([decipher.update(wrappedDek), decipher.final()]);
+    } catch {
+      throw new Error("Key unwrap failed: GCM authentication failed");
+    } finally {
+      // Zeroize the ephemeral KEK copy
+      kekBuffer.fill(0);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Key Management
+  // ---------------------------------------------------------------------------
+
+  async destroyKey(handle: string): Promise<void> {
+    this.assertInitialized();
+
+    const entry = this.keys.get(handle);
+    if (entry) {
+      // Zeroize key material before deletion
+      if (entry.keyBytes) {
+        entry.keyBytes.fill(0);
+      }
+      this.keys.delete(handle);
+    }
+  }
+
+  async hasKey(handle: string): Promise<boolean> {
+    return this.keys.has(handle);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private Helpers
+  // ---------------------------------------------------------------------------
+
+  private assertInitialized(): void {
+    if (!this.initialized) {
+      throw new Error("SimulatorCryptoAdapter not initialized");
+    }
+  }
+
+  private requireKey(handle: string): SimulatorKeyEntry {
+    const entry = this.keys.get(handle);
+    if (!entry) {
+      throw new Error(`Key not found: ${handle}`);
+    }
+    return entry;
+  }
+
+  private assertKeyType(
+    entry: SimulatorKeyEntry,
+    expectedType: SimulatorKeyEntry["type"],
+    handle: string,
+  ): void {
+    if (entry.type !== expectedType) {
+      throw new Error(
+        `Key ${handle} is type '${entry.type}', expected '${expectedType}'`,
+      );
+    }
+  }
+}

--- a/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
+++ b/modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts
@@ -374,9 +374,11 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
 
     const kekBuffer = Buffer.from(entry.keyBytes);
     const iv = randomBytes(12);
+    // Select algorithm based on key size
+    const algorithm = entry.aesBits === 128 ? "aes-128-gcm" : "aes-256-gcm";
 
     try {
-      const cipher = createCipheriv("aes-256-gcm", kekBuffer, iv);
+      const cipher = createCipheriv(algorithm, kekBuffer, iv);
       const wrappedDek = Buffer.concat([
         cipher.update(dekBytes),
         cipher.final(),
@@ -406,9 +408,11 @@ export class SimulatorCryptoAdapter implements HsmCryptoPort {
     }
 
     const kekBuffer = Buffer.from(entry.keyBytes);
+    // Select algorithm based on key size
+    const algorithm = entry.aesBits === 128 ? "aes-128-gcm" : "aes-256-gcm";
 
     try {
-      const decipher = createDecipheriv("aes-256-gcm", kekBuffer, iv);
+      const decipher = createDecipheriv(algorithm, kekBuffer, iv);
       decipher.setAuthTag(authTag);
       return Buffer.concat([decipher.update(wrappedDek), decipher.final()]);
     } catch {

--- a/modules/hsm/src/infrastructure/key-store.ts
+++ b/modules/hsm/src/infrastructure/key-store.ts
@@ -15,4 +15,8 @@ export class InMemoryKeyStore implements KeyStore {
   set(label: string, entry: KeyEntry): void {
     this.data.set(label, entry);
   }
+
+  delete(label: string): boolean {
+    return this.data.delete(label);
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.6.0",
         "globals": "^17.5.0",
+        "graphene-pk11": "^2.3.6",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.2",
@@ -5709,6 +5710,24 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphene-pk11": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/graphene-pk11/-/graphene-pk11-2.3.6.tgz",
+      "integrity": "sha512-ol9Pf7XDv5UTjh1DPqtmQVZQqUheiXBzQVXQWRCLWq78+brKQB0Kum/s0NGEcsd/5NQQG8MFA2U/KNujEoC1fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkcs11js": "^2.1.6",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/PeculiarVentures"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -9573,9 +9592,9 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/pkcs11js/-/pkcs11js-2.1.6.tgz",
       "integrity": "sha512-+t5jxzB749q8GaEd1yNx3l98xYuaVK6WW/Vjg1Mk1Iy5bMu/A5W4O/9wZGrpOknWF6lFQSb12FXX+eSNxdriwA==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12118,10 +12137,11 @@
     },
     "packages/enterprise-blockchain": {
       "name": "@psavelis/enterprise-blockchain",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@noble/post-quantum": "^0.6.1"
+        "@noble/post-quantum": "^0.6.1",
+        "@psavelis/enterprise-blockchain": "file:"
       },
       "engines": {
         "node": ">=22.14.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "example:quantum-safe-payment": "tsx examples/quantum-safe-payment/index.ts",
     "example:quantum-safe-merkle-root-payment": "tsx examples/quantum-safe-merkle-root-payment/index.ts",
     "example:stark-settlement": "tsx examples/stark-cross-border-settlement/index.ts",
+    "example:hsm-pkcs11": "tsx examples/hsm-real-pkcs11/index.ts",
     "sbom": "cyclonedx-npm --output-file sbom.json --output-format JSON",
     "prepare": "husky"
   },
@@ -58,13 +59,13 @@
     "@grpc/proto-loader": "^0.8.0",
     "@hyperledger/fabric-gateway": "^1.10.1",
     "@noble/post-quantum": "^0.6.1",
-    "starknet": "^9.4.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/sdk-node": "^0.214.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
-    "ethers": "^6.16.0"
+    "ethers": "^6.16.0",
+    "starknet": "^9.4.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",
@@ -79,6 +80,7 @@
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.6.0",
     "globals": "^17.5.0",
+    "graphene-pk11": "^2.3.6",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.6.0",
     "globals": "^17.5.0",
-    "graphene-pk11": "^2.3.6",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.2",
@@ -100,6 +99,9 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
+  },
+  "optionalDependencies": {
+    "graphene-pk11": "^2.3.6"
   },
   "overrides": {
     "picomatch": "^4.0.4"

--- a/packages/enterprise-blockchain/package.json
+++ b/packages/enterprise-blockchain/package.json
@@ -114,7 +114,8 @@
     "@opentelemetry/sdk-node": "^0.214.0",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "ethers": "^6.16.0",
-    "starknet": "^9.4.0"
+    "starknet": "^9.4.0",
+    "graphene-pk11": "^2.3.0"
   },
   "peerDependenciesMeta": {
     "@grpc/grpc-js": {
@@ -151,6 +152,9 @@
       "optional": true
     },
     "starknet": {
+      "optional": true
+    },
+    "graphene-pk11": {
       "optional": true
     }
   }

--- a/scripts/run-all-examples.ts
+++ b/scripts/run-all-examples.ts
@@ -21,6 +21,7 @@ const examples = [
     "stark cross-border settlement",
     "examples/stark-cross-border-settlement/index.ts",
   ],
+  ["hsm real pkcs11", "examples/hsm-real-pkcs11/index.ts"],
 ] as const;
 
 for (const [label, path] of examples) {


### PR DESCRIPTION
## Summary

Implements production-grade PKCS#11 HSM integration while maintaining full backward compatibility with the existing `HsmClient` API.

- **HsmCryptoPort interface** in domain layer (hexagonal architecture)
- **SimulatorCryptoAdapter**: software HSM using `node:crypto`
- **Pkcs11CryptoAdapter**: real hardware HSM via `graphene-pk11`
- **Full key suite**: EC P-256/P-384, Ed25519, RSA-2048/4096, AES-128/256
- **Async method variants** with `*Async()` suffix for hardware HSM operations
- **SoftHSM2 Docker setup** for integration testing

## Changes

### Domain Layer
- `modules/hsm/src/domain/ports.ts`: Added `HsmCryptoPort`, `SigningAlgorithm`, `EcCurve`, `EdCurve`, `RsaKeySize`, `AesKeySize`, `HsmCryptoConfig` types
- `modules/hsm/src/domain/entities.ts`: Added `handle` field to key entries, new type definitions

### Infrastructure Layer
- `modules/hsm/src/infrastructure/adapters/simulator-crypto-adapter.ts`: Software HSM implementation
- `modules/hsm/src/infrastructure/adapters/pkcs11-crypto-adapter.ts`: Real PKCS#11 implementation (~600 LOC)
- `modules/hsm/src/infrastructure/key-store.ts`: Added `delete()` method

### Application Layer
- `modules/hsm/src/application/asymmetric-key-service.ts`: Added async methods, Ed25519 fix using `crypto.sign()`
- `modules/hsm/src/application/symmetric-key-service.ts`: Added async methods
- `modules/hsm/src/application/envelope-encryption-service.ts`: Added async methods

### Facade
- `modules/hsm/src/index.ts`: Updated `HsmClient` with `HsmClientConfig`, async methods, PKCS#11 support

### Infrastructure
- `infra/softhsm2/Dockerfile`: SoftHSM2 Docker image
- `infra/softhsm2/docker-compose.yml`: Docker Compose configuration

### Example
- `examples/hsm-real-pkcs11/index.ts`: Demonstrates all key types with PKCS#11

### Dependencies
- `graphene-pk11` added as optional peer dependency

## Test plan

- [x] `npm run verify` passes (format, lint, typecheck, test, examples)
- [x] All 266 tests pass
- [x] All 15 examples run successfully
- [x] PKCS#11 example works in simulator mode
- [x] CI pipeline passes